### PR TITLE
Implement More Auto Groups

### DIFF
--- a/.makefile.docs
+++ b/.makefile.docs
@@ -2,8 +2,8 @@ help                 This help.
 build                Build docker dev image
 run                  Run docker dev container
 setup                Setup project
-lint                 Lint with pre-commit
-lint-all             Lint all files with pre-commit
+lint                 Lint with pre-commit and render docs
+lint-all             Lint all files with pre-commit and render docs
 tests                Tests with Terratest
 test-basic           Test the basic example
 test-complete        Test the complete example

--- a/.terraform-docs
+++ b/.terraform-docs
@@ -17,7 +17,7 @@ content: |-
 
   ### Security Group with basic rules
 
-  Create a security group with HTTPS from `10.0.0.0/24` and `all-all` to the public internet rules.
+  Create a security group with HTTPS from `10.0.0.0/24`, `all-all` from self, and `all-all` to the public internet rules.
 
   ```hcl
   {{ include "examples/basic/.main.tf.docs" }}
@@ -27,7 +27,7 @@ content: |-
 
   ### Security Group with complete rules
 
-  Create a security group with a combination of both managed and custom rules. This also demonstrates the conditional create functionality.
+  Create a security group with a combination of both managed, custom, computed, and auto group rules. This also demonstrates the conditional create functionality.
 
   <details><summary>Click to show</summary>
 

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,12 @@ docs:
 	./bin/render-terratest-docs.sh
 	./bin/render-makefile-docs.sh
 
-lint: docs ## Lint with pre-commit
+lint: docs ## Lint with pre-commit and render docs
 	git add -A
 	pre-commit run
 	git add -A
 
-lint-all: docs ## Lint all files with pre-commit
+lint-all: docs ## Lint all files with pre-commit and render docs
 	git add -A
 	pre-commit run --all-files
 	git add -A

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint-all: docs ## Lint all files with pre-commit and render docs
 	pre-commit run --all-files
 	git add -A
 
-tests: test-basic test-complete test-custom-rules test-managed-rules test-computed-rules test-rules-only ## Tests with Terratest
+tests: test-basic test-complete test-custom-rules test-managed-rules test-computed-rules test-rules-only lint ## Tests with Terratest
 
 test-basic: ## Test the basic example
 	go test test/terraform_basic_test.go -timeout 5m -v |& tee test/terraform_basic_test.log

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ module "security_group" {
     }
   ]
 
-  create_auto_group_ingress_all_from_self_rules         = true
+  create_auto_group_ingress_all_from_self_rules         = false # already created with a custom ingress rule
   create_auto_group_egress_all_to_public_internet_rules = true
 
   tags = {
@@ -487,7 +487,7 @@ Run Terratest using the [Makefile](https://github.com/aidanmelen/terraform-aws-s
 
 ```
 --- PASS: TestTerraformBasicExample (27.99s)
-FAIL
+--- PASS: TestTerraformCompleteExample (52.93s)
 --- PASS: TestTerraformCustomRulesExample (36.94s)
 --- PASS: TestTerraformManagedRulesExample (37.68s)
 --- PASS: TestTerraformComputedRulesExample (35.14s)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This module aims to implement **ALL** combinations of arguments supported by AWS
 
 ### Security Group with basic rules
 
-Create a security group with HTTPS from `10.0.0.0/24` and `all-all` to the public internet rules.
+Create a security group with HTTPS from `10.0.0.0/24`, `all-all` from self, and `all-all` to the public internet rules.
 
 ```hcl
 module "security_group" {
@@ -57,7 +57,7 @@ Please see the [Basic Example](https://github.com/aidanmelen/terraform-aws-secur
 
 ### Security Group with complete rules
 
-Create a security group with a combination of both managed and custom rules. This also demonstrates the conditional create functionality.
+Create a security group with a combination of both managed, custom, computed, and auto group rules. This also demonstrates the conditional create functionality.
 
 <details><summary>Click to show</summary>
 
@@ -486,12 +486,12 @@ Run Terratest using the [Makefile](https://github.com/aidanmelen/terraform-aws-s
 ### Results
 
 ```
---- PASS: TestTerraformBasicExample (24.72s)
---- PASS: TestTerraformCompleteExample (48.69s)
---- PASS: TestTerraformCustomRulesExample (36.72s)
---- PASS: TestTerraformManagedRulesExample (37.11s)
---- PASS: TestTerraformComputedRulesExample (33.16s)
---- PASS: TestTerraformRulesOnlyExample (23.53s)
+FAIL
+FAIL
+FAIL
+FAIL
+FAIL
+FAIL
 ```
 
 ## Makefile Targets
@@ -501,8 +501,8 @@ help                 This help.
 build                Build docker dev image
 run                  Run docker dev container
 setup                Setup project
-lint                 Lint with pre-commit
-lint-all             Lint all files with pre-commit
+lint                 Lint with pre-commit and render docs
+lint-all             Lint all files with pre-commit and render docs
 tests                Tests with Terratest
 test-basic           Test the basic example
 test-complete        Test the complete example
@@ -529,7 +529,9 @@ clean                Clean project
 | <a name="input_computed_managed_ingress_rules"></a> [computed\_managed\_ingress\_rules](#input\_computed\_managed\_ingress\_rules) | List of dynamic managed ingress rules. The key is the rule description and the value is the managed rule name. | `any` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create security group and all rules | `bool` | `true` | no |
 | <a name="input_create_auto_group_egress_all_to_public_internet_rules"></a> [create\_auto\_group\_egress\_all\_to\_public\_internet\_rules](#input\_create\_auto\_group\_egress\_all\_to\_public\_internet\_rules) | Whether to create auto group egress all to public internet rules (IPV4/IPV6). | `bool` | `false` | no |
-| <a name="input_create_auto_group_ingress_all_from_self_rules"></a> [create\_auto\_group\_ingress\_all\_from\_self\_rules](#input\_create\_auto\_group\_ingress\_all\_from\_self\_rules) | Whether to create auto group ingress all to self rules. | `bool` | `false` | no |
+| <a name="input_create_auto_group_ingress_all_from_self_rules"></a> [create\_auto\_group\_ingress\_all\_from\_self\_rules](#input\_create\_auto\_group\_ingress\_all\_from\_self\_rules) | Whether to create auto group ingress all from self security group rules. | `bool` | `false` | no |
+| <a name="input_create_auto_group_ingress_http_from_public_internet_rules"></a> [create\_auto\_group\_ingress\_http\_from\_public\_internet\_rules](#input\_create\_auto\_group\_ingress\_http\_from\_public\_internet\_rules) | Whether to create auto group ingress HTTP from the public internet rules. | `bool` | `false` | no |
+| <a name="input_create_auto_group_ingress_https_from_public_internet_rules"></a> [create\_auto\_group\_ingress\_https\_from\_public\_internet\_rules](#input\_create\_auto\_group\_ingress\_https\_from\_public\_internet\_rules) | Whether to create auto group ingress HTTPS from the public internet rules. | `bool` | `false` | no |
 | <a name="input_create_sg"></a> [create\_sg](#input\_create\_sg) | Whether to create security group and all rules. | `bool` | `true` | no |
 | <a name="input_create_timeout"></a> [create\_timeout](#input\_create\_timeout) | Time to wait for a security group to be created. | `string` | `"10m"` | no |
 | <a name="input_delete_timeout"></a> [delete\_timeout](#input\_delete\_timeout) | Time to wait for a security group to be deleted. | `string` | `"15m"` | no |
@@ -548,10 +550,14 @@ clean                Clean project
 
 | Name | Description |
 |------|-------------|
+| <a name="output_auto_group_egress_all_to_public_internet_rule_ids"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
-| <a name="output_auto_group_egress_to_public_internet_rule_ids"></a> [auto\_group\_egress\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
 | <a name="output_auto_group_ingress_all_from_self_rule_ids"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_ids](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_ids) | The auto group ingress all to self rule IDs. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_ids"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_ids](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_ids) | The auto group ingress HTTP from the public internet rule IDs. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_ids"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_ids](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_ids) | The auto group ingress HTTPS from the public internet rule IDs. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/README.md
+++ b/README.md
@@ -486,12 +486,12 @@ Run Terratest using the [Makefile](https://github.com/aidanmelen/terraform-aws-s
 ### Results
 
 ```
+--- PASS: TestTerraformBasicExample (27.99s)
 FAIL
-FAIL
-FAIL
-FAIL
-FAIL
-FAIL
+--- PASS: TestTerraformCustomRulesExample (36.94s)
+--- PASS: TestTerraformManagedRulesExample (37.68s)
+--- PASS: TestTerraformComputedRulesExample (35.14s)
+--- PASS: TestTerraformRulesOnlyExample (24.34s)
 ```
 
 ## Makefile Targets

--- a/auto_group_rules.tf
+++ b/auto_group_rules.tf
@@ -1,16 +1,16 @@
 ###############################################################################
-# Auto Group Rules
+# Auto Group Ingress Rules
 ###############################################################################
 
 #tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
 
   # create terraform resource with identifiable ID
-  for_each = var.create && var.create_auto_group_ingress_all_from_self_rules ? { "ingress-all-from-self" = null } : {}
+  for_each = var.create && var.create_auto_group_ingress_all_from_self_rules ? { "ingress-all-all-from-self" = null } : {}
 
   type              = "ingress"
   security_group_id = local.self_sg_id
-  description       = "Opening up ingress all ports to self."
+  description       = "Opening up ingress all ports from self security group."
 
   from_port = -1
   to_port   = -1
@@ -20,10 +20,50 @@ resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
 }
 
 #tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr
+resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules" {
+
+  # create terraform resource with identifiable ID
+  for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+  type              = "ingress"
+  security_group_id = local.self_sg_id
+  description       = "Opening up ingress HTTPS from the public internet."
+
+  from_port = -1
+  to_port   = -1
+  protocol  = "-1"
+
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+#tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr
+resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules" {
+
+  # create terraform resource with identifiable ID
+  for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+  type              = "ingress"
+  security_group_id = local.self_sg_id
+  description       = "Opening up ingress HTTP from the public internet. Please consider using HTTPS instead."
+
+  from_port = -1
+  to_port   = -1
+  protocol  = "-1"
+
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+###############################################################################
+# Auto Group Egress Rules
+###############################################################################
+
+#tfsec:ignore:aws-ec2-no-public-ingress-sgr tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
 
   # create terraform resource with identifiable ID
-  for_each = var.create && var.create_auto_group_egress_all_to_public_internet_rules ? { "egress-all-to-public-internet" = null } : {}
+  for_each = var.create && var.create_auto_group_egress_all_to_public_internet_rules ? { "egress-all-all-to-public-internet" = null } : {}
 
   type              = "egress"
   security_group_id = local.self_sg_id

--- a/auto_group_rules.tf
+++ b/auto_group_rules.tf
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "auto_group_ingress_https_from_public_interne
 resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules" {
 
   # create terraform resource with identifiable ID
-  for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
   type              = "ingress"
   security_group_id = local.self_sg_id

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -68,8 +68,8 @@ module "security_group" {
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
-| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
-| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # Basic Security Group example
 
-Create a security group with HTTPS from `10.0.0.0/24` and `all-all` to the public internet rules.
+Create a security group with HTTPS from `10.0.0.0/24`, `all-all` from self, and `all-all` to the public internet rules.
 
 Data sources are used to discover existing VPC resources (VPC, default security group, s3 endpoint prefix list).
 
@@ -67,9 +67,9 @@ module "security_group" {
 | Name | Description |
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
-| <a name="output_auto_group_egress_to_public_internet_rule_ids"></a> [auto\_group\_egress\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_ids"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_ids](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_ids) | The auto group ingress all to self rule IDs. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
+| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -61,12 +61,12 @@ output "auto_group_ingress_all_from_self_rule_keys" {
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_ingress_https_from_self_rule_keys" {
+output "auto_group_ingress_https_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTPS from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
 }
 
-output "auto_group_ingress_http_from_self_rule_keys" {
+output "auto_group_ingress_http_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTP from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -56,19 +56,19 @@ output "computed_managed_egress_rule_ids" {
 # Auto Group Rules
 ###############################################################################
 
-output "auto_group_ingress_all_from_self_rule_ids" {
-  description = "The auto group ingress all to self rule IDs."
-  value       = module.security_group.auto_group_ingress_all_from_self_rule_ids
-}
-
 output "auto_group_ingress_all_from_self_rule_keys" {
   description = "The auto group ingress all to self rule key."
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_egress_to_public_internet_rule_ids" {
-  description = "The auto group egress all to public internet rule IDs."
-  value       = module.security_group.auto_group_egress_to_public_internet_rule_ids
+output "auto_group_ingress_https_from_self_rule_keys" {
+  description = "The auto group ingress HTTPS from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
+}
+
+output "auto_group_ingress_http_from_self_rule_keys" {
+  description = "The auto group ingress HTTP from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }
 
 output "auto_group_egress_all_to_public_internet_rule_keys" {

--- a/examples/complete/.main.tf.docs
+++ b/examples/complete/.main.tf.docs
@@ -98,7 +98,7 @@ module "security_group" {
     }
   ]
 
-  create_auto_group_ingress_all_from_self_rules         = true
+  create_auto_group_ingress_all_from_self_rules         = false # already created with a custom ingress rule
   create_auto_group_egress_all_to_public_internet_rules = true
 
   tags = {

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -163,8 +163,8 @@ module "disabled_sg" {
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
-| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
-| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -121,7 +121,7 @@ module "security_group" {
     }
   ]
 
-  create_auto_group_ingress_all_from_self_rules         = true
+  create_auto_group_ingress_all_from_self_rules         = false # already created with a custom ingress rule
   create_auto_group_egress_all_to_public_internet_rules = true
 
   tags = {

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,6 +1,6 @@
 # Complete Security Group example
 
-Create a security group with a combination of both managed and custom rules. This also demonstrates the conditional create functionality.
+Create a security group with a combination of both managed, custom, computed, and auto group rules. This also demonstrates the conditional create functionality.
 
 Data sources are used to discover existing VPC resources (VPC, default security group, s3 endpoint prefix list).
 
@@ -162,9 +162,9 @@ module "disabled_sg" {
 | Name | Description |
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
-| <a name="output_auto_group_egress_to_public_internet_rule_ids"></a> [auto\_group\_egress\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_ids"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_ids](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_ids) | The auto group ingress all to self rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule keys. |
+| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
+| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -97,7 +97,7 @@ module "security_group" {
     }
   ]
 
-  create_auto_group_ingress_all_from_self_rules         = true
+  create_auto_group_ingress_all_from_self_rules         = false # already created with a custom ingress rule
   create_auto_group_egress_all_to_public_internet_rules = true
 
   tags = {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -52,24 +52,23 @@ output "computed_managed_egress_rule_ids" {
   value       = module.security_group.computed_managed_egress_rule_ids
 }
 
-
 ###############################################################################
 # Auto Group Rules
 ###############################################################################
 
-output "auto_group_ingress_all_from_self_rule_ids" {
-  description = "The auto group ingress all to self rule IDs."
-  value       = module.security_group.auto_group_ingress_all_from_self_rule_ids
-}
-
 output "auto_group_ingress_all_from_self_rule_keys" {
-  description = "The auto group ingress all to self rule keys."
+  description = "The auto group ingress all to self rule key."
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_egress_to_public_internet_rule_ids" {
-  description = "The auto group egress all to public internet rule IDs."
-  value       = module.security_group.auto_group_egress_to_public_internet_rule_ids
+output "auto_group_ingress_https_from_self_rule_keys" {
+  description = "The auto group ingress HTTPS from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
+}
+
+output "auto_group_ingress_http_from_self_rule_keys" {
+  description = "The auto group ingress HTTP from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }
 
 output "auto_group_egress_all_to_public_internet_rule_keys" {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -61,12 +61,12 @@ output "auto_group_ingress_all_from_self_rule_keys" {
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_ingress_https_from_self_rule_keys" {
+output "auto_group_ingress_https_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTPS from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
 }
 
-output "auto_group_ingress_http_from_self_rule_keys" {
+output "auto_group_ingress_http_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTP from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }
@@ -75,7 +75,6 @@ output "auto_group_egress_all_to_public_internet_rule_keys" {
   description = "The auto group egress all to public internet rule keys."
   value       = module.security_group.auto_group_egress_all_to_public_internet_rule_keys
 }
-
 ################################################################################
 # Disabled creation
 ################################################################################

--- a/examples/computed_rules/README.md
+++ b/examples/computed_rules/README.md
@@ -117,9 +117,9 @@ module "security_group" {
 | Name | Description |
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
-| <a name="output_auto_group_egress_to_public_internet_rule_ids"></a> [auto\_group\_egress\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_ids"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_ids](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_ids) | The auto group ingress all to self rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule keys. |
+| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
+| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/computed_rules/README.md
+++ b/examples/computed_rules/README.md
@@ -118,8 +118,8 @@ module "security_group" {
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
-| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
-| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/computed_rules/outputs.tf
+++ b/examples/computed_rules/outputs.tf
@@ -61,12 +61,12 @@ output "auto_group_ingress_all_from_self_rule_keys" {
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_ingress_https_from_self_rule_keys" {
+output "auto_group_ingress_https_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTPS from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
 }
 
-output "auto_group_ingress_http_from_self_rule_keys" {
+output "auto_group_ingress_http_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTP from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }

--- a/examples/computed_rules/outputs.tf
+++ b/examples/computed_rules/outputs.tf
@@ -52,24 +52,23 @@ output "computed_managed_egress_rule_ids" {
   value       = module.security_group.computed_managed_egress_rule_ids
 }
 
-
 ###############################################################################
 # Auto Group Rules
 ###############################################################################
 
-output "auto_group_ingress_all_from_self_rule_ids" {
-  description = "The auto group ingress all to self rule IDs."
-  value       = module.security_group.auto_group_ingress_all_from_self_rule_ids
-}
-
 output "auto_group_ingress_all_from_self_rule_keys" {
-  description = "The auto group ingress all to self rule keys."
+  description = "The auto group ingress all to self rule key."
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_egress_to_public_internet_rule_ids" {
-  description = "The auto group egress all to public internet rule IDs."
-  value       = module.security_group.auto_group_egress_to_public_internet_rule_ids
+output "auto_group_ingress_https_from_self_rule_keys" {
+  description = "The auto group ingress HTTPS from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
+}
+
+output "auto_group_ingress_http_from_self_rule_keys" {
+  description = "The auto group ingress HTTP from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }
 
 output "auto_group_egress_all_to_public_internet_rule_keys" {

--- a/examples/custom_rules/README.md
+++ b/examples/custom_rules/README.md
@@ -117,9 +117,9 @@ module "security_group" {
 | Name | Description |
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
-| <a name="output_auto_group_egress_to_public_internet_rule_ids"></a> [auto\_group\_egress\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_ids"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_ids](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_ids) | The auto group ingress all to self rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule keys. |
+| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
+| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/custom_rules/README.md
+++ b/examples/custom_rules/README.md
@@ -118,8 +118,8 @@ module "security_group" {
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
-| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
-| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/custom_rules/outputs.tf
+++ b/examples/custom_rules/outputs.tf
@@ -61,12 +61,12 @@ output "auto_group_ingress_all_from_self_rule_keys" {
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_ingress_https_from_self_rule_keys" {
+output "auto_group_ingress_https_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTPS from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
 }
 
-output "auto_group_ingress_http_from_self_rule_keys" {
+output "auto_group_ingress_http_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTP from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }

--- a/examples/custom_rules/outputs.tf
+++ b/examples/custom_rules/outputs.tf
@@ -52,24 +52,23 @@ output "computed_managed_egress_rule_ids" {
   value       = module.security_group.computed_managed_egress_rule_ids
 }
 
-
 ###############################################################################
 # Auto Group Rules
 ###############################################################################
 
-output "auto_group_ingress_all_from_self_rule_ids" {
-  description = "The auto group ingress all to self rule IDs."
-  value       = module.security_group.auto_group_ingress_all_from_self_rule_ids
-}
-
 output "auto_group_ingress_all_from_self_rule_keys" {
-  description = "The auto group ingress all to self rule keys."
+  description = "The auto group ingress all to self rule key."
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_egress_to_public_internet_rule_ids" {
-  description = "The auto group egress all to public internet rule IDs."
-  value       = module.security_group.auto_group_egress_to_public_internet_rule_ids
+output "auto_group_ingress_https_from_self_rule_keys" {
+  description = "The auto group ingress HTTPS from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
+}
+
+output "auto_group_ingress_http_from_self_rule_keys" {
+  description = "The auto group ingress HTTP from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }
 
 output "auto_group_egress_all_to_public_internet_rule_keys" {

--- a/examples/managed_rules/README.md
+++ b/examples/managed_rules/README.md
@@ -97,9 +97,9 @@ module "security_group" {
 | Name | Description |
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
-| <a name="output_auto_group_egress_to_public_internet_rule_ids"></a> [auto\_group\_egress\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_ids"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_ids](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_ids) | The auto group ingress all to self rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule keys. |
+| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
+| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/managed_rules/README.md
+++ b/examples/managed_rules/README.md
@@ -98,8 +98,8 @@ module "security_group" {
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
-| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
-| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/managed_rules/outputs.tf
+++ b/examples/managed_rules/outputs.tf
@@ -61,12 +61,12 @@ output "auto_group_ingress_all_from_self_rule_keys" {
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_ingress_https_from_self_rule_keys" {
+output "auto_group_ingress_https_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTPS from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
 }
 
-output "auto_group_ingress_http_from_self_rule_keys" {
+output "auto_group_ingress_http_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTP from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }

--- a/examples/managed_rules/outputs.tf
+++ b/examples/managed_rules/outputs.tf
@@ -52,24 +52,23 @@ output "computed_managed_egress_rule_ids" {
   value       = module.security_group.computed_managed_egress_rule_ids
 }
 
-
 ###############################################################################
 # Auto Group Rules
 ###############################################################################
 
-output "auto_group_ingress_all_from_self_rule_ids" {
-  description = "The auto group ingress all to self rule IDs."
-  value       = module.security_group.auto_group_ingress_all_from_self_rule_ids
-}
-
 output "auto_group_ingress_all_from_self_rule_keys" {
-  description = "The auto group ingress all to self rule keys."
+  description = "The auto group ingress all to self rule key."
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_egress_to_public_internet_rule_ids" {
-  description = "The auto group egress all to public internet rule IDs."
-  value       = module.security_group.auto_group_egress_to_public_internet_rule_ids
+output "auto_group_ingress_https_from_self_rule_keys" {
+  description = "The auto group ingress HTTPS from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
+}
+
+output "auto_group_ingress_http_from_self_rule_keys" {
+  description = "The auto group ingress HTTP from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }
 
 output "auto_group_egress_all_to_public_internet_rule_keys" {

--- a/examples/rules_only/README.md
+++ b/examples/rules_only/README.md
@@ -70,9 +70,9 @@ module "security_group" {
 | Name | Description |
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
-| <a name="output_auto_group_egress_to_public_internet_rule_ids"></a> [auto\_group\_egress\_to\_public\_internet\_rule\_ids](#output\_auto\_group\_egress\_to\_public\_internet\_rule\_ids) | The auto group egress all to public internet rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_ids"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_ids](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_ids) | The auto group ingress all to self rule IDs. |
-| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule keys. |
+| <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
+| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/rules_only/README.md
+++ b/examples/rules_only/README.md
@@ -71,8 +71,8 @@ module "security_group" {
 |------|-------------|
 | <a name="output_auto_group_egress_all_to_public_internet_rule_keys"></a> [auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys](#output\_auto\_group\_egress\_all\_to\_public\_internet\_rule\_keys) | The auto group egress all to public internet rule keys. |
 | <a name="output_auto_group_ingress_all_from_self_rule_keys"></a> [auto\_group\_ingress\_all\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_all\_from\_self\_rule\_keys) | The auto group ingress all to self rule key. |
-| <a name="output_auto_group_ingress_http_from_self_rule_keys"></a> [auto\_group\_ingress\_http\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_self\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
-| <a name="output_auto_group_ingress_https_from_self_rule_keys"></a> [auto\_group\_ingress\_https\_from\_self\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_self\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
+| <a name="output_auto_group_ingress_http_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_http\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTP from the public internet rule keys. |
+| <a name="output_auto_group_ingress_https_from_public_internet_rule_keys"></a> [auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys](#output\_auto\_group\_ingress\_https\_from\_public\_internet\_rule\_keys) | The auto group ingress HTTPS from the public internet rule keys. |
 | <a name="output_computed_egress_rule_ids"></a> [computed\_egress\_rule\_ids](#output\_computed\_egress\_rule\_ids) | The computed egress security group rule IDs. |
 | <a name="output_computed_ingress_rule_ids"></a> [computed\_ingress\_rule\_ids](#output\_computed\_ingress\_rule\_ids) | The computed ingress security group rule IDs. |
 | <a name="output_computed_managed_egress_rule_ids"></a> [computed\_managed\_egress\_rule\_ids](#output\_computed\_managed\_egress\_rule\_ids) | The computed managed egress security group rule IDs. |

--- a/examples/rules_only/outputs.tf
+++ b/examples/rules_only/outputs.tf
@@ -57,24 +57,23 @@ output "computed_managed_egress_rule_ids" {
   value       = module.security_group.computed_managed_egress_rule_ids
 }
 
-
 ###############################################################################
 # Auto Group Rules
 ###############################################################################
 
-output "auto_group_ingress_all_from_self_rule_ids" {
-  description = "The auto group ingress all to self rule IDs."
-  value       = module.security_group.auto_group_ingress_all_from_self_rule_ids
-}
-
 output "auto_group_ingress_all_from_self_rule_keys" {
-  description = "The auto group ingress all to self rule keys."
+  description = "The auto group ingress all to self rule key."
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_egress_to_public_internet_rule_ids" {
-  description = "The auto group egress all to public internet rule IDs."
-  value       = module.security_group.auto_group_egress_to_public_internet_rule_ids
+output "auto_group_ingress_https_from_self_rule_keys" {
+  description = "The auto group ingress HTTPS from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
+}
+
+output "auto_group_ingress_http_from_self_rule_keys" {
+  description = "The auto group ingress HTTP from the public internet rule keys."
+  value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }
 
 output "auto_group_egress_all_to_public_internet_rule_keys" {

--- a/examples/rules_only/outputs.tf
+++ b/examples/rules_only/outputs.tf
@@ -66,12 +66,12 @@ output "auto_group_ingress_all_from_self_rule_keys" {
   value       = module.security_group.auto_group_ingress_all_from_self_rule_keys
 }
 
-output "auto_group_ingress_https_from_self_rule_keys" {
+output "auto_group_ingress_https_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTPS from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_https_from_public_internet_rule_keys
 }
 
-output "auto_group_ingress_http_from_self_rule_keys" {
+output "auto_group_ingress_http_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTP from the public internet rule keys."
   value       = module.security_group.auto_group_ingress_http_from_public_internet_rule_keys
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -114,15 +114,35 @@ output "computed_managed_egress_rule_ids" {
 
 output "auto_group_ingress_all_from_self_rule_ids" {
   description = "The auto group ingress all to self rule IDs."
-  value       = try([for rule in aws_security_group_rule.auto_group_egress_all_to_public_internet_rules : rule["id"] if rule["type"] == "egress"], null)
+  value       = try([for rule in aws_security_group_rule.auto_group_ingress_all_from_self_rules : rule["id"] if rule["type"] == "egress"], null)
 }
 
 output "auto_group_ingress_all_from_self_rule_keys" {
   description = "The auto group ingress all to self rule key."
-  value       = try([for key, rule in aws_security_group_rule.auto_group_egress_all_to_public_internet_rules : key if rule["type"] == "egress"], null)
+  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_all_from_self_rules : key if rule["type"] == "egress"], null)
 }
 
-output "auto_group_egress_to_public_internet_rule_ids" {
+output "auto_group_ingress_https_from_public_internet_rule_ids" {
+  description = "The auto group ingress HTTPS from the public internet rule IDs."
+  value       = try([for rule in aws_security_group_rule.auto_group_ingress_https_from_public_internet_rules : rule["id"] if rule["type"] == "egress"], null)
+}
+
+output "auto_group_ingress_https_from_public_internet_rule_keys" {
+  description = "The auto group ingress HTTPS from the public internet rule keys."
+  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_https_from_public_internet_rules : key if rule["type"] == "egress"], null)
+}
+
+output "auto_group_ingress_http_from_public_internet_rule_ids" {
+  description = "The auto group ingress HTTP from the public internet rule IDs."
+  value       = try([for rule in aws_security_group_rule.auto_group_ingress_http_from_public_internet_rules : rule["id"] if rule["type"] == "egress"], null)
+}
+
+output "auto_group_ingress_http_from_public_internet_rule_keys" {
+  description = "The auto group ingress HTTP from the public internet rule keys."
+  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_http_from_public_internet_rules : key if rule["type"] == "egress"], null)
+}
+
+output "auto_group_egress_all_to_public_internet_rule_ids" {
   description = "The auto group egress all to public internet rule IDs."
   value       = try([for rule in aws_security_group_rule.auto_group_egress_all_to_public_internet_rules : rule["id"] if rule["type"] == "egress"], null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -114,32 +114,32 @@ output "computed_managed_egress_rule_ids" {
 
 output "auto_group_ingress_all_from_self_rule_ids" {
   description = "The auto group ingress all to self rule IDs."
-  value       = try([for rule in aws_security_group_rule.auto_group_ingress_all_from_self_rules : rule["id"] if rule["type"] == "egress"], null)
+  value       = try([for rule in aws_security_group_rule.auto_group_ingress_all_from_self_rules : rule["id"] if rule["type"] == "ingress"], null)
 }
 
 output "auto_group_ingress_all_from_self_rule_keys" {
   description = "The auto group ingress all to self rule key."
-  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_all_from_self_rules : key if rule["type"] == "egress"], null)
+  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_all_from_self_rules : key if rule["type"] == "ingress"], null)
 }
 
 output "auto_group_ingress_https_from_public_internet_rule_ids" {
   description = "The auto group ingress HTTPS from the public internet rule IDs."
-  value       = try([for rule in aws_security_group_rule.auto_group_ingress_https_from_public_internet_rules : rule["id"] if rule["type"] == "egress"], null)
+  value       = try([for rule in aws_security_group_rule.auto_group_ingress_https_from_public_internet_rules : rule["id"] if rule["type"] == "ingress"], null)
 }
 
 output "auto_group_ingress_https_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTPS from the public internet rule keys."
-  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_https_from_public_internet_rules : key if rule["type"] == "egress"], null)
+  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_https_from_public_internet_rules : key if rule["type"] == "ingress"], null)
 }
 
 output "auto_group_ingress_http_from_public_internet_rule_ids" {
   description = "The auto group ingress HTTP from the public internet rule IDs."
-  value       = try([for rule in aws_security_group_rule.auto_group_ingress_http_from_public_internet_rules : rule["id"] if rule["type"] == "egress"], null)
+  value       = try([for rule in aws_security_group_rule.auto_group_ingress_http_from_public_internet_rules : rule["id"] if rule["type"] == "ingress"], null)
 }
 
 output "auto_group_ingress_http_from_public_internet_rule_keys" {
   description = "The auto group ingress HTTP from the public internet rule keys."
-  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_http_from_public_internet_rules : key if rule["type"] == "egress"], null)
+  value       = try([for key, rule in aws_security_group_rule.auto_group_ingress_http_from_public_internet_rules : key if rule["type"] == "ingress"], null)
 }
 
 output "auto_group_egress_all_to_public_internet_rule_ids" {

--- a/test/.terratest.docs
+++ b/test/.terratest.docs
@@ -1,5 +1,5 @@
 --- PASS: TestTerraformBasicExample (27.99s)
-FAIL
+--- PASS: TestTerraformCompleteExample (52.93s)
 --- PASS: TestTerraformCustomRulesExample (36.94s)
 --- PASS: TestTerraformManagedRulesExample (37.68s)
 --- PASS: TestTerraformComputedRulesExample (35.14s)

--- a/test/.terratest.docs
+++ b/test/.terratest.docs
@@ -1,6 +1,6 @@
+--- PASS: TestTerraformBasicExample (27.99s)
 FAIL
-FAIL
-FAIL
-FAIL
-FAIL
-FAIL
+--- PASS: TestTerraformCustomRulesExample (36.94s)
+--- PASS: TestTerraformManagedRulesExample (37.68s)
+--- PASS: TestTerraformComputedRulesExample (35.14s)
+--- PASS: TestTerraformRulesOnlyExample (24.34s)

--- a/test/.terratest.docs
+++ b/test/.terratest.docs
@@ -1,6 +1,6 @@
---- PASS: TestTerraformBasicExample (24.72s)
---- PASS: TestTerraformCompleteExample (48.69s)
---- PASS: TestTerraformCustomRulesExample (36.72s)
---- PASS: TestTerraformManagedRulesExample (37.11s)
---- PASS: TestTerraformComputedRulesExample (33.16s)
---- PASS: TestTerraformRulesOnlyExample (23.53s)
+FAIL
+FAIL
+FAIL
+FAIL
+FAIL
+FAIL

--- a/test/terraform_basic_test.go
+++ b/test/terraform_basic_test.go
@@ -31,6 +31,7 @@ func TestTerraformBasicExample(t *testing.T) {
 	actualComputedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_ingress_rule_ids"))
 	actualComputedManagedIngressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_egress_rule_ids"))
 	actualComputedManagedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_ingress_rule_ids"))
+	actualAutoGroupIngressAllFromSelfRuleKeys := terraform.Output(t, terraformOptions, "auto_group_ingress_all_from_self_rule_keys")
 	actualAutoGroupEgressAllToPublicInternetRuleKeys := terraform.Output(t, terraformOptions, "auto_group_egress_all_to_public_internet_rule_keys")
 
 	expectedIngressRuleKeys := "[]"
@@ -41,7 +42,8 @@ func TestTerraformBasicExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 0
 	expectedComputedManagedIngressRuleLength := 0
 	expectedComputedManagedEgressRuleLength := 0
-	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[egress-all-to-public-internet]"
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[egress-all-to-public-internet]"
+	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[egress-all-all-to-public-internet]"
 
 	assert.Equal(t, expectedIngressRuleKeys, actualIngressRuleKeys, "Map %q should match %q", expectedIngressRuleKeys, actualIngressRuleKeys)
 	assert.Equal(t, expectedManagedIngressRuleKeys, actualManagedIngressRuleKeys, "Map %q should match %q", expectedManagedIngressRuleKeys, actualManagedIngressRuleKeys)
@@ -51,5 +53,6 @@ func TestTerraformBasicExample(t *testing.T) {
 	assert.Equal(t, expectedComputedEgressRuleLength, actualComputedEgressRuleLength, "Map %q should match %q", expectedComputedEgressRuleLength, actualComputedEgressRuleLength)
 	assert.Equal(t, expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength, "Map %q should match %q", expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength)
 	assert.Equal(t, expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength, "Map %q should match %q", expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength)
+	assert.Equal(t, expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys, "Map %q should match %q", expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys)
 	assert.Equal(t, expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys, "Map %q should match %q", expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys)
 }

--- a/test/terraform_basic_test.go
+++ b/test/terraform_basic_test.go
@@ -42,7 +42,7 @@ func TestTerraformBasicExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 0
 	expectedComputedManagedIngressRuleLength := 0
 	expectedComputedManagedEgressRuleLength := 0
-	expectedAutoGroupIngressAllFromSelfRuleKeys := "[egress-all-to-public-internet]"
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[ingress-all-all-from-self]"
 	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[egress-all-all-to-public-internet]"
 
 	assert.Equal(t, expectedIngressRuleKeys, actualIngressRuleKeys, "Map %q should match %q", expectedIngressRuleKeys, actualIngressRuleKeys)

--- a/test/terraform_basic_test.log
+++ b/test/terraform_basic_test.log
@@ -1,309 +1,161 @@
 === RUN   TestTerraformBasicExample
-TestTerraformBasicExample 2022-08-24T04:31:07Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformBasicExample 2022-08-24T04:31:07Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformBasicExample 2022-08-24T04:31:07Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformBasicExample 2022-08-24T04:31:07Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:07Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformBasicExample 2022-08-24T04:31:08Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:08Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformBasicExample 2022-08-24T04:31:08Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: [0m[32m
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: should now work.
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformBasicExample 2022-08-24T04:31:09Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T04:31:09Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + create
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66: Terraform will perform the following actions:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + description            = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + id                     = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + name                   = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + tags                   = {
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "Name" = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + tags_all               = {
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "Example"    = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "Name"       = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + timeouts {
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + create = "10m"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + delete = "15m"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"] will be created
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + cidr_blocks              = [
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:         ]
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + from_port                = -1
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + id                       = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "::/0",
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:         ]
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + protocol                 = "-1"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + self                     = false
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + to_port                  = -1
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + type                     = "egress"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be created
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + cidr_blocks              = [
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:           + "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:         ]
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + description              = "My Service"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + from_port                = 443
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + id                       = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + self                     = false
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + to_port                  = 443
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:       + type                     = "ingress"
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66: Plan: 3 to add, 0 to change, 0 to destroy.
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66: Changes to Outputs:
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + auto_group_egress_to_public_internet_rule_ids      = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + auto_group_ingress_all_from_self_rule_ids          = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys         = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + computed_egress_rule_ids                           = []
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + computed_ingress_rule_ids                          = []
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + computed_managed_egress_rule_ids                   = []
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + computed_managed_ingress_rule_ids                  = []
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + egress_rule_keys                                   = []
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + ingress_rule_keys                                  = []
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + managed_egress_rule_keys                           = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:12Z logger.go:66:   + managed_ingress_rule_keys                          = (known after apply)
-TestTerraformBasicExample 2022-08-24T04:31:13Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
-TestTerraformBasicExample 2022-08-24T04:31:15Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-002f3616812d8c27b]
-TestTerraformBasicExample 2022-08-24T04:31:16Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creating...
-TestTerraformBasicExample 2022-08-24T04:31:16Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Creating...
-TestTerraformBasicExample 2022-08-24T04:31:16Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creation complete after 1s [id=sgrule-308402309]
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Creation complete after 1s [id=sgrule-1136464184]
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: Outputs:
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = [
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:   "egress-all-to-public-internet",
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: auto_group_egress_to_public_internet_rule_ids = [
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:   "sgrule-1136464184",
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: auto_group_ingress_all_from_self_rule_ids = [
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:   "sgrule-1136464184",
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = [
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:   "egress-all-to-public-internet",
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: computed_egress_rule_ids = []
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: computed_ingress_rule_ids = []
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: computed_managed_egress_rule_ids = []
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: computed_managed_ingress_rule_ids = []
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: egress_rule_keys = []
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: ingress_rule_keys = []
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: managed_egress_rule_keys = []
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: managed_ingress_rule_keys = [
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24",
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-24T04:31:17Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:17Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:18Z logger.go:66: []
-TestTerraformBasicExample 2022-08-24T04:31:18Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:18Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:19Z logger.go:66: ["ingress-https-443-tcp-from-10.0.0.0/24"]
-TestTerraformBasicExample 2022-08-24T04:31:19Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:19Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:19Z logger.go:66: []
-TestTerraformBasicExample 2022-08-24T04:31:19Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:19Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:20Z logger.go:66: []
-TestTerraformBasicExample 2022-08-24T04:31:20Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:20Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:21Z logger.go:66: []
-TestTerraformBasicExample 2022-08-24T04:31:21Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:21Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:22Z logger.go:66: []
-TestTerraformBasicExample 2022-08-24T04:31:22Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:22Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:23Z logger.go:66: []
-TestTerraformBasicExample 2022-08-24T04:31:23Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:23Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformBasicExample 2022-08-24T04:31:24Z logger.go:66: []
-TestTerraformBasicExample 2022-08-24T04:31:24Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:24Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformBasicExample 2022-08-24T04:31:24Z logger.go:66: ["egress-all-to-public-internet"]
-TestTerraformBasicExample 2022-08-24T04:31:24Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T04:31:24Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T04:31:27Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-002f3616812d8c27b]
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-308402309]
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Refreshing state... [id=sgrule-1136464184]
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - destroy
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: Terraform will perform the following actions:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-002f3616812d8c27b" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - description            = "ex-basic" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - egress                 = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - cidr_blocks      = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:                   - "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:                 ]
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - from_port        = 0
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:                   - "::/0",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:                 ]
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - protocol         = "-1"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - security_groups  = []
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - self             = false
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - to_port          = 0
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:             },
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - id                     = "sg-002f3616812d8c27b" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - ingress                = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - cidr_blocks      = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:                   - "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:                 ]
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - description      = "My Service"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - from_port        = 443
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - protocol         = "tcp"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - security_groups  = []
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - self             = false
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:               - to_port          = 443
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:             },
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - name                   = "ex-basic" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - tags                   = {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "Name" = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         } -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - tags_all               = {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "Example"    = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "Name"       = "ex-basic"
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         } -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - timeouts {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - create = "10m" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - delete = "15m" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"] will be destroyed
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - cidr_blocks       = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - id                = "sgrule-1136464184" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "::/0",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - security_group_id = "sg-002f3616812d8c27b" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - self              = false -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - type              = "egress" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be destroyed
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - cidr_blocks       = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:           - "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - description       = "My Service" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - id                = "sgrule-308402309" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - security_group_id = "sg-002f3616812d8c27b" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - self              = false -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: Plan: 0 to add, 0 to change, 3 to destroy.
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66: Changes to Outputs:
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - "egress-all-to-public-internet",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - auto_group_egress_to_public_internet_rule_ids      = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - "sgrule-1136464184",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - auto_group_ingress_all_from_self_rule_ids          = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - "sgrule-1136464184",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys         = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - "egress-all-to-public-internet",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - computed_egress_rule_ids                           = [] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - computed_ingress_rule_ids                          = [] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - computed_managed_egress_rule_ids                   = [] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - computed_managed_ingress_rule_ids                  = [] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - egress_rule_keys                                   = [] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - ingress_rule_keys                                  = [] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - managed_egress_rule_keys                           = [] -> null
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:   - managed_ingress_rule_keys                          = [
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:       - "ingress-https-443-tcp-from-10.0.0.0/24",
-TestTerraformBasicExample 2022-08-24T04:31:28Z logger.go:66:     ] -> null
-TestTerraformBasicExample 2022-08-24T04:31:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destroying... [id=sgrule-308402309]
-TestTerraformBasicExample 2022-08-24T04:31:29Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Destroying... [id=sgrule-1136464184]
-TestTerraformBasicExample 2022-08-24T04:31:30Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destruction complete after 1s
-TestTerraformBasicExample 2022-08-24T04:31:31Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Destruction complete after 1s
-TestTerraformBasicExample 2022-08-24T04:31:31Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-002f3616812d8c27b]
-TestTerraformBasicExample 2022-08-24T04:31:32Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformBasicExample 2022-08-24T04:31:32Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T04:31:32Z logger.go:66: Destroy complete! Resources: 3 destroyed.
---- PASS: TestTerraformBasicExample (24.72s)
-PASS
-ok  	command-line-arguments	24.731s
+TestTerraformBasicExample 2022-08-24T14:34:31Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformBasicExample 2022-08-24T14:34:32Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:32Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformBasicExample 2022-08-24T14:34:32Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: [0m[32m
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: should now work.
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformBasicExample 2022-08-24T14:34:33Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: An input variable with the name
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: An input variable with the name
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformBasicExample 2022-08-24T14:34:35Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    apply.go:15:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_basic_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformBasicExample
+TestTerraformBasicExample 2022-08-24T14:34:35Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: An input variable with the name
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: An input variable with the name
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformBasicExample 2022-08-24T14:34:36Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    destroy.go:11:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
+        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
+        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
+        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_basic_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformBasicExample
+--- FAIL: TestTerraformBasicExample (5.93s)
+FAIL
+FAIL	command-line-arguments	5.944s
+FAIL

--- a/test/terraform_basic_test.log
+++ b/test/terraform_basic_test.log
@@ -1,161 +1,345 @@
 === RUN   TestTerraformBasicExample
-TestTerraformBasicExample 2022-08-24T14:34:31Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:31Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformBasicExample 2022-08-24T14:34:32Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:32Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformBasicExample 2022-08-24T14:34:32Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: [0m[32m
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: should now work.
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformBasicExample 2022-08-24T14:34:33Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T14:34:33Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: An input variable with the name
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: An input variable with the name
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformBasicExample 2022-08-24T14:34:35Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    apply.go:15:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_basic_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformBasicExample
-TestTerraformBasicExample 2022-08-24T14:34:35Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: An input variable with the name
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: An input variable with the name
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformBasicExample 2022-08-24T14:34:36Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    destroy.go:11:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
-        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
-        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
-        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_basic_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformBasicExample
---- FAIL: TestTerraformBasicExample (5.93s)
-FAIL
-FAIL	command-line-arguments	5.944s
-FAIL
+TestTerraformBasicExample 2022-08-24T15:14:26Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformBasicExample 2022-08-24T15:14:26Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformBasicExample 2022-08-24T15:14:26Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformBasicExample 2022-08-24T15:14:26Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:26Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformBasicExample 2022-08-24T15:14:27Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:27Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformBasicExample 2022-08-24T15:14:27Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: [0m[32m
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: should now work.
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformBasicExample 2022-08-24T15:14:28Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T15:14:28Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + create
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66: Terraform will perform the following actions:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + description            = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + id                     = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + name                   = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + tags                   = {
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "Name" = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + tags_all               = {
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "Example"    = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "Name"       = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + timeouts {
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + create = "10m"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + delete = "15m"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be created
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + cidr_blocks              = [
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:         ]
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + from_port                = -1
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "::/0",
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:         ]
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + protocol                 = "-1"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + self                     = false
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + to_port                  = -1
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + type                     = "egress"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"] will be created
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + description              = "Opening up ingress all ports from self security group."
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + from_port                = -1
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + protocol                 = "-1"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + self                     = true
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + to_port                  = -1
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be created
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + cidr_blocks              = [
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:           + "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:         ]
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + description              = "My Service"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + from_port                = 443
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + self                     = false
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + to_port                  = 443
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66: Plan: 4 to add, 0 to change, 0 to destroy.
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66: Changes to Outputs:
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + computed_egress_rule_ids                                = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + computed_ingress_rule_ids                               = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + computed_managed_egress_rule_ids                        = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + computed_managed_ingress_rule_ids                       = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + egress_rule_keys                                        = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + ingress_rule_keys                                       = []
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + managed_egress_rule_keys                                = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:31Z logger.go:66:   + managed_ingress_rule_keys                               = (known after apply)
+TestTerraformBasicExample 2022-08-24T15:14:32Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
+TestTerraformBasicExample 2022-08-24T15:14:34Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-0d97a1afac6af9f4e]
+TestTerraformBasicExample 2022-08-24T15:14:34Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creating...
+TestTerraformBasicExample 2022-08-24T15:14:34Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Creating...
+TestTerraformBasicExample 2022-08-24T15:14:34Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creating...
+TestTerraformBasicExample 2022-08-24T15:14:35Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creation complete after 1s [id=sgrule-1882270926]
+TestTerraformBasicExample 2022-08-24T15:14:36Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Creation complete after 1s [id=sgrule-3776428601]
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creation complete after 2s [id=sgrule-1000589769]
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: Outputs:
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = [
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66:   "egress-all-all-to-public-internet",
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: ]
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = [
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66:   "ingress-all-all-from-self",
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: ]
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: auto_group_ingress_http_from_public_internet_rule_keys = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: computed_egress_rule_ids = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: computed_ingress_rule_ids = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: computed_managed_egress_rule_ids = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: computed_managed_ingress_rule_ids = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: egress_rule_keys = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: ingress_rule_keys = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: managed_egress_rule_keys = []
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: managed_ingress_rule_keys = [
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24",
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: ]
+TestTerraformBasicExample 2022-08-24T15:14:37Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:37Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:38Z logger.go:66: []
+TestTerraformBasicExample 2022-08-24T15:14:38Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:38Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:38Z logger.go:66: ["ingress-https-443-tcp-from-10.0.0.0/24"]
+TestTerraformBasicExample 2022-08-24T15:14:38Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:38Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:39Z logger.go:66: []
+TestTerraformBasicExample 2022-08-24T15:14:39Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:39Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:40Z logger.go:66: []
+TestTerraformBasicExample 2022-08-24T15:14:40Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:40Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:41Z logger.go:66: []
+TestTerraformBasicExample 2022-08-24T15:14:41Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:41Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:42Z logger.go:66: []
+TestTerraformBasicExample 2022-08-24T15:14:42Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:42Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:43Z logger.go:66: []
+TestTerraformBasicExample 2022-08-24T15:14:43Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:43Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformBasicExample 2022-08-24T15:14:43Z logger.go:66: []
+TestTerraformBasicExample 2022-08-24T15:14:43Z retry.go:91: terraform [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:43Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:44Z logger.go:66: ["ingress-all-all-from-self"]
+TestTerraformBasicExample 2022-08-24T15:14:44Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:44Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformBasicExample 2022-08-24T15:14:45Z logger.go:66: ["egress-all-all-to-public-internet"]
+TestTerraformBasicExample 2022-08-24T15:14:45Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T15:14:45Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformBasicExample 2022-08-24T15:14:48Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformBasicExample 2022-08-24T15:14:48Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
+TestTerraformBasicExample 2022-08-24T15:14:48Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-0d97a1afac6af9f4e]
+TestTerraformBasicExample 2022-08-24T15:14:48Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Refreshing state... [id=sgrule-1882270926]
+TestTerraformBasicExample 2022-08-24T15:14:48Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-3776428601]
+TestTerraformBasicExample 2022-08-24T15:14:48Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-1000589769]
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - destroy
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66: Terraform will perform the following actions:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0d97a1afac6af9f4e" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - description            = "ex-basic" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - egress                 = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - cidr_blocks      = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:                   - "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:                 ]
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - from_port        = 0
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:                   - "::/0",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:                 ]
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - protocol         = "-1"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - security_groups  = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - self             = false
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - to_port          = 0
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:             },
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - id                     = "sg-0d97a1afac6af9f4e" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - ingress                = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - cidr_blocks      = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:                   - "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:                 ]
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - description      = "My Service"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - from_port        = 443
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - protocol         = "tcp"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - security_groups  = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - self             = false
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - to_port          = 443
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:             },
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - cidr_blocks      = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - description      = "Opening up ingress all ports from self security group."
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - from_port        = 0
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - protocol         = "-1"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - security_groups  = []
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - self             = true
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:               - to_port          = 0
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:             },
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - name                   = "ex-basic" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - tags                   = {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "Name" = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         } -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - tags_all               = {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "Example"    = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "Name"       = "ex-basic"
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         } -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - timeouts {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - create = "10m" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - delete = "15m" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be destroyed
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - cidr_blocks       = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - id                = "sgrule-1882270926" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "::/0",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - security_group_id = "sg-0d97a1afac6af9f4e" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - self              = false -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - type              = "egress" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"] will be destroyed
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - description       = "Opening up ingress all ports from self security group." -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - id                = "sgrule-3776428601" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - security_group_id = "sg-0d97a1afac6af9f4e" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - self              = true -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be destroyed
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - cidr_blocks       = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:           - "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - description       = "My Service" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - id                = "sgrule-1000589769" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - security_group_id = "sg-0d97a1afac6af9f4e" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - self              = false -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66: Plan: 0 to add, 0 to change, 4 to destroy.
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66: Changes to Outputs:
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - "egress-all-all-to-public-internet",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:     ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - "ingress-all-all-from-self",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:     ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - computed_egress_rule_ids                                = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - computed_ingress_rule_ids                               = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - computed_managed_egress_rule_ids                        = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - egress_rule_keys                                        = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - ingress_rule_keys                                       = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - managed_egress_rule_keys                                = [] -> null
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:   - managed_ingress_rule_keys                               = [
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:       - "ingress-https-443-tcp-from-10.0.0.0/24",
+TestTerraformBasicExample 2022-08-24T15:14:49Z logger.go:66:     ] -> null
+TestTerraformBasicExample 2022-08-24T15:14:50Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destroying... [id=sgrule-1000589769]
+TestTerraformBasicExample 2022-08-24T15:14:50Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Destroying... [id=sgrule-3776428601]
+TestTerraformBasicExample 2022-08-24T15:14:50Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destroying... [id=sgrule-1882270926]
+TestTerraformBasicExample 2022-08-24T15:14:51Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Destruction complete after 0s
+TestTerraformBasicExample 2022-08-24T15:14:52Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destruction complete after 1s
+TestTerraformBasicExample 2022-08-24T15:14:52Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destruction complete after 2s
+TestTerraformBasicExample 2022-08-24T15:14:52Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-0d97a1afac6af9f4e]
+TestTerraformBasicExample 2022-08-24T15:14:54Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformBasicExample 2022-08-24T15:14:54Z logger.go:66:
+TestTerraformBasicExample 2022-08-24T15:14:54Z logger.go:66: Destroy complete! Resources: 4 destroyed.
+--- PASS: TestTerraformBasicExample (27.99s)
+PASS
+ok  	command-line-arguments	28.003s

--- a/test/terraform_basic_test.log
+++ b/test/terraform_basic_test.log
@@ -34,7 +34,7 @@ TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
 TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
 TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66:
 TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: An input variable with the name
 TestTerraformBasicExample 2022-08-24T14:34:35Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -54,7 +54,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -78,7 +78,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -101,7 +101,7 @@ TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
 TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
 TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66:
 TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: An input variable with the name
 TestTerraformBasicExample 2022-08-24T14:34:36Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -121,7 +121,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -148,7 +148,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been

--- a/test/terraform_complete_test.go
+++ b/test/terraform_complete_test.go
@@ -31,6 +31,7 @@ func TestTerraformCompleteExample(t *testing.T) {
 	actualComputedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_ingress_rule_ids"))
 	actualComputedManagedIngressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_egress_rule_ids"))
 	actualComputedManagedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_ingress_rule_ids"))
+	actualAutoGroupIngressAllFromSelfRuleKeys := terraform.Output(t, terraformOptions, "auto_group_ingress_all_from_self_rule_keys")
 	actualAutoGroupEgressAllToPublicInternetRuleKeys := terraform.Output(t, terraformOptions, "auto_group_egress_all_to_public_internet_rule_keys")
 	actualDisabledSgId := terraform.Output(t, terraformOptions, "disabled_sg_id")
 
@@ -42,17 +43,19 @@ func TestTerraformCompleteExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 1
 	expectedComputedManagedIngressRuleLength := 1
 	expectedComputedManagedEgressRuleLength := 1
-	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[egress-all-to-public-internet]"
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[ingress-all-all-from-self]"
+	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[egress-all-all-to-public-internet]"
 	expectedDisabledSgId := "I was not created"
 
 	assert.Equal(t, expectedIngressRuleKeys, actualIngressRuleKeys, "Map %q should match %q", expectedIngressRuleKeys, actualIngressRuleKeys)
-	assert.Equal(t, expectedEgressRuleKeys, actualEgressRuleKeys, "Map %q should match %q", expectedEgressRuleKeys, actualEgressRuleKeys)
 	assert.Equal(t, expectedManagedIngressRuleKeys, actualManagedIngressRuleKeys, "Map %q should match %q", expectedManagedIngressRuleKeys, actualManagedIngressRuleKeys)
+	assert.Equal(t, expectedEgressRuleKeys, actualEgressRuleKeys, "Map %q should match %q", expectedEgressRuleKeys, actualEgressRuleKeys)
 	assert.Equal(t, expectedManagedEgressRuleKeys, actualManagedEgressRuleKeys, "Map %q should match %q", expectedManagedEgressRuleKeys, actualManagedEgressRuleKeys)
 	assert.Equal(t, expectedComputedIngressRuleLength, actualComputedIngressRuleLength, "Map %q should match %q", expectedComputedIngressRuleLength, actualComputedIngressRuleLength)
 	assert.Equal(t, expectedComputedEgressRuleLength, actualComputedEgressRuleLength, "Map %q should match %q", expectedComputedEgressRuleLength, actualComputedEgressRuleLength)
 	assert.Equal(t, expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength, "Map %q should match %q", expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength)
 	assert.Equal(t, expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength, "Map %q should match %q", expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength)
+	assert.Equal(t, expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys, "Map %q should match %q", expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys)
 	assert.Equal(t, expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys, "Map %q should match %q", expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys)
 	assert.Equal(t, expectedDisabledSgId, actualDisabledSgId, "Map %q should match %q", expectedDisabledSgId, actualDisabledSgId)
 }

--- a/test/terraform_complete_test.go
+++ b/test/terraform_complete_test.go
@@ -43,7 +43,7 @@ func TestTerraformCompleteExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 1
 	expectedComputedManagedIngressRuleLength := 1
 	expectedComputedManagedEgressRuleLength := 1
-	expectedAutoGroupIngressAllFromSelfRuleKeys := "[ingress-all-all-from-self]"
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[]"
 	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[egress-all-all-to-public-internet]"
 	expectedDisabledSgId := "I was not created"
 

--- a/test/terraform_complete_test.log
+++ b/test/terraform_complete_test.log
@@ -44,7 +44,7 @@ TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -54,7 +54,7 @@ TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
 TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -84,7 +84,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -94,7 +94,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -128,7 +128,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -138,7 +138,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -171,7 +171,7 @@ TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -181,7 +181,7 @@ TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
 TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -211,7 +211,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -221,7 +221,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -258,7 +258,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -268,7 +268,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been

--- a/test/terraform_complete_test.log
+++ b/test/terraform_complete_test.log
@@ -1,281 +1,1026 @@
 === RUN   TestTerraformCompleteExample
-TestTerraformCompleteExample 2022-08-24T14:34:38Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformCompleteExample 2022-08-24T14:34:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:39Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformCompleteExample 2022-08-24T14:34:39Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: [0m[32m
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: should now work.
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformCompleteExample 2022-08-24T14:34:40Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:42Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T15:14:55Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformCompleteExample 2022-08-24T15:14:56Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:14:56Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformCompleteExample 2022-08-24T15:14:56Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: [0m[32m
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: should now work.
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformCompleteExample 2022-08-24T15:14:57Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:14:59Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-24T15:14:59Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + create
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + address_family = "IPv4"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + arn            = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id             = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + max_entries    = 5
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name           = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + owner_id       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags_all       = {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + version        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + entry {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + cidr        = "172.31.0.0/16"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + description = "Primary"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # aws_security_group.other will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group" "other" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description            = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name                   = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name" = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name"       = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description            = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name                   = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name" = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name"       = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + timeouts {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + create = "10m"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + delete = "15m"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "::/0",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "Opening up ingress all ports from self security group."
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = true
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 80
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 80
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 80
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 80
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 22
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 22
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 22
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 22
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = true
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = true
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be created
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Plan: 19 to add, 0 to change, 0 to destroy.
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Changes to Outputs:
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_egress_rule_ids                                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_ingress_rule_ids                               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_managed_egress_rule_ids                        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_managed_ingress_rule_ids                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + disabled_sg_id                                          = "I was not created"
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + egress_rule_keys                                        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + ingress_rule_keys                                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + managed_egress_rule_keys                                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + managed_ingress_rule_keys                               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:15:01Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:01Z logger.go:66: aws_security_group.other: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:01Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:02Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-0027f2e7276e6b628]
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-088f339996d8a12c1]
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-0ce9760dd7fd54d43]
+TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 1s [id=sgrule-1297727356]
+TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:05Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Creation complete after 2s [id=sgrule-251523704]
+TestTerraformCompleteExample 2022-08-24T15:15:05Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:06Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creation complete after 2s [id=sgrule-2314322188]
+TestTerraformCompleteExample 2022-08-24T15:15:06Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:06Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 3s [id=sgrule-3316891827]
+TestTerraformCompleteExample 2022-08-24T15:15:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creation complete after 4s [id=sgrule-1184747838]
+TestTerraformCompleteExample 2022-08-24T15:15:07Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:08Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 4s [id=sgrule-1378512088]
+TestTerraformCompleteExample 2022-08-24T15:15:08Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:15:09Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 5s [id=sgrule-1114986369]
+TestTerraformCompleteExample 2022-08-24T15:15:09Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 6s [id=sgrule-1256776488]
+TestTerraformCompleteExample 2022-08-24T15:15:10Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creation complete after 7s [id=sgrule-3451758508]
+TestTerraformCompleteExample 2022-08-24T15:15:11Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 7s [id=sgrule-3694565669]
+TestTerraformCompleteExample 2022-08-24T15:15:12Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creation complete after 7s [id=sgrule-1492769384]
+TestTerraformCompleteExample 2022-08-24T15:15:13Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 8s [id=sgrule-1316103192]
+TestTerraformCompleteExample 2022-08-24T15:15:14Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creation complete after 7s [id=sgrule-3267436176]
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 7s [id=sgrule-3333521439]
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 8s [id=sgrule-4133694951]
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: Error: [WARN] A duplicate Security Group rule was found on (sg-088f339996d8a12c1). This may be
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: a side effect of a now-fixed Terraform issue causing two security groups with
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: identical attributes but different source_security_group_ids to overwrite each
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: sg-088f339996d8a12c1, ALL, ALLOW" already exists
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: 	status code: 400, request id: aabc3d09-09dd-42a4-b604-6a731bdcb613
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:   with module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"],
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:   on ../../custom_rules.tf line 63, in resource "aws_security_group_rule" "rules":
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:   63: resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:15Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: [WARN] A duplicate Security Group rule was found on (sg-088f339996d8a12c1). This may be
+a side effect of a now-fixed Terraform issue causing two security groups with
+identical attributes but different source_security_group_ids to overwrite each
+other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
+information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: sg-088f339996d8a12c1, ALL, ALLOW" already exists
+	status code: 400, request id: aabc3d09-09dd-42a4-b604-6a731bdcb613
 
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+  with module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"],
+  on ../../custom_rules.tf line 63, in resource "aws_security_group_rule" "rules":
+  63: resource "aws_security_group_rule" "rules" {
+}
     apply.go:15:
         	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
         	            				/workspaces/terraform-aws-security-group/test/terraform_complete_test.go:23
         	Error:      	Received unexpected error:
         	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
+        	            	Error: [WARN] A duplicate Security Group rule was found on (sg-088f339996d8a12c1). This may be
+        	            	a side effect of a now-fixed Terraform issue causing two security groups with
+        	            	identical attributes but different source_security_group_ids to overwrite each
+        	            	other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
+        	            	information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: sg-088f339996d8a12c1, ALL, ALLOW" already exists
+        	            		status code: 400, request id: aabc3d09-09dd-42a4-b604-6a731bdcb613
 
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	            	  with module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"],
+        	            	  on ../../custom_rules.tf line 63, in resource "aws_security_group_rule" "rules":
+        	            	  63: resource "aws_security_group_rule" "rules" {
+        	            	}
         	Test:       	TestTerraformCompleteExample
-TestTerraformCompleteExample 2022-08-24T14:34:42Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformCompleteExample 2022-08-24T14:34:44Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    destroy.go:11:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
-        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
-        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
-        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_complete_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformCompleteExample
---- FAIL: TestTerraformCompleteExample (6.18s)
+TestTerraformCompleteExample 2022-08-24T15:15:15Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:15:18Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-24T15:15:18Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:15:18Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-0ce9760dd7fd54d43]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-088f339996d8a12c1]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-0027f2e7276e6b628]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-4133694951]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-3333521439]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1378512088]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Refreshing state... [id=sgrule-2314322188]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1316103192]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-3451758508]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1297727356]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-3694565669]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-3267436176]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-251523704]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-1492769384]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1114986369]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-1184747838]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1256776488]
+TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-3316891827]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - destroy
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - address_family = "IPv4" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:326504147071:prefix-list/pl-0027f2e7276e6b628" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id             = "pl-0027f2e7276e6b628" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - max_entries    = 5 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - name           = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - owner_id       = "326504147071" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags           = {} -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags_all       = {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - version        = 1 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - entry {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - description = "Primary" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # aws_security_group.other will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group" "other" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0ce9760dd7fd54d43" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description            = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - egress                 = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                     = "sg-0ce9760dd7fd54d43" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ingress                = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - name                   = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name" = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name"       = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description            = "ex-complete" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - egress                 = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "::/0",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = ""
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 80
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-0027f2e7276e6b628",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 80
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = true
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = -1
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = -1
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 22
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 22
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-0027f2e7276e6b628",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                     = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ingress                = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = ""
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 80
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-0ce9760dd7fd54d43",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 80
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "Opening up ingress all ports from self security group."
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = true
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-0ce9760dd7fd54d43",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = -1
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = -1
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 5432
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 22
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 22
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - name                   = "ex-complete" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name" = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name"       = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - timeouts {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - create = "10m" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - delete = "15m" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-2314322188" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "::/0",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "Opening up ingress all ports from self security group." -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-251523704" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = true -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3316891827" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-0027f2e7276e6b628",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-3333521439" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-0ce9760dd7fd54d43" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "https-443-tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1256776488" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-0027f2e7276e6b628",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description              = "https-443-tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-4133694951" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-0ce9760dd7fd54d43" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1297727356" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1316103192" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-68a54001" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3267436176" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3694565669" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1378512088" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-68a54001" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3451758508" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1114986369" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = true -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-1492769384" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-1184747838" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Plan: 0 to add, 0 to change, 18 to destroy.
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Changes to Outputs:
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-all-all-to-public-internet",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-all-all-from-self",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_egress_rule_ids                                = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-3316891827",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_ingress_rule_ids                               = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-3333521439",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_managed_egress_rule_ids                        = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-1256776488",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-4133694951",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - disabled_sg_id                                          = "I was not created" -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - managed_egress_rule_keys                                = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-ssh-tcp-to-pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - managed_ingress_rule_keys                               = [
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-ssh-tcp-from-pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1378512088]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-3316891827]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-1492769384]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-3267436176]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Destroying... [id=sgrule-251523704]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-3451758508]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1316103192]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-4133694951]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destroying... [id=sgrule-2314322188]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-1184747838]
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-3694565669]
+TestTerraformCompleteExample 2022-08-24T15:15:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:15:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-3333521439]
+TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destruction complete after 2s
+TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1297727356]
+TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destruction complete after 3s
+TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-1114986369]
+TestTerraformCompleteExample 2022-08-24T15:15:24Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destruction complete after 3s
+TestTerraformCompleteExample 2022-08-24T15:15:24Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-1256776488]
+TestTerraformCompleteExample 2022-08-24T15:15:24Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 4s
+TestTerraformCompleteExample 2022-08-24T15:15:25Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Destruction complete after 5s
+TestTerraformCompleteExample 2022-08-24T15:15:26Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 5s
+TestTerraformCompleteExample 2022-08-24T15:15:27Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-24T15:15:27Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:15:28Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-24T15:15:28Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:15:28Z logger.go:66: aws_security_group.other: Destroying... [id=sg-0ce9760dd7fd54d43]
+TestTerraformCompleteExample 2022-08-24T15:15:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:15:30Z logger.go:66: aws_security_group.other: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:15:30Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-24T15:15:31Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:15:31Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-0027f2e7276e6b628]
+TestTerraformCompleteExample 2022-08-24T15:15:31Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-088f339996d8a12c1]
+TestTerraformCompleteExample 2022-08-24T15:15:32Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:15:38Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:15:38Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:15:38Z logger.go:66: Destroy complete! Resources: 18 destroyed.
+--- FAIL: TestTerraformCompleteExample (42.89s)
 FAIL
-FAIL	command-line-arguments	6.199s
+FAIL	command-line-arguments	42.905s
 FAIL

--- a/test/terraform_complete_test.log
+++ b/test/terraform_complete_test.log
@@ -1,1060 +1,281 @@
 === RUN   TestTerraformCompleteExample
-TestTerraformCompleteExample 2022-08-24T04:31:33Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-24T04:31:33Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-24T04:31:33Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformCompleteExample 2022-08-24T04:31:33Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:33Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformCompleteExample 2022-08-24T04:31:34Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:34Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformCompleteExample 2022-08-24T04:31:34Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: [0m[32m
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: should now work.
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformCompleteExample 2022-08-24T04:31:35Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T04:31:35Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T04:31:38Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-24T04:31:38Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-24T04:31:38Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 1s [id=pl-68a54001]
-TestTerraformCompleteExample 2022-08-24T04:31:38Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
-TestTerraformCompleteExample 2022-08-24T04:31:38Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + create
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + address_family = "IPv4"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + arn            = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id             = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + max_entries    = 5
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + name           = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + owner_id       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + tags_all       = {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + version        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + entry {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + cidr        = "172.31.0.0/16"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + description = "Primary"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # aws_security_group.other will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group" "other" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description            = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + name                   = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + tags                   = {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "Name" = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + tags_all               = {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "Name"       = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description            = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + name                   = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + tags                   = {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "Name" = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + tags_all               = {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "Name"       = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + timeouts {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + create = "10m"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + delete = "15m"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "::/0",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 80
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 80
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 80
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 80
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 5432
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 5432
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 22
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 22
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 5432
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 5432
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = 22
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:           + "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = 22
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "egress-all-all-all-to-self"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = true
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = true
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be created
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66: Plan: 18 to add, 0 to change, 0 to destroy.
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66: Changes to Outputs:
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + auto_group_egress_to_public_internet_rule_ids      = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + auto_group_ingress_all_from_self_rule_ids          = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys         = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + computed_egress_rule_ids                           = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + computed_ingress_rule_ids                          = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + computed_managed_egress_rule_ids                   = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + computed_managed_ingress_rule_ids                  = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + disabled_sg_id                                     = "I was not created"
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + egress_rule_keys                                   = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + ingress_rule_keys                                  = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + managed_egress_rule_keys                           = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:39Z logger.go:66:   + managed_ingress_rule_keys                          = (known after apply)
-TestTerraformCompleteExample 2022-08-24T04:31:40Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:40Z logger.go:66: aws_security_group.other: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:40Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:41Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 2s [id=pl-072c7b65ef1be3afa]
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-0782597d1bd129a61]
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-03a9f28ccfc1df4e0]
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:42Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:43Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 1s [id=sgrule-2025826228]
-TestTerraformCompleteExample 2022-08-24T04:31:43Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:43Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 2s [id=sgrule-2348133159]
-TestTerraformCompleteExample 2022-08-24T04:31:43Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:44Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Creation complete after 3s [id=sgrule-2629990382]
-TestTerraformCompleteExample 2022-08-24T04:31:44Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:45Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 3s [id=sgrule-1236050544]
-TestTerraformCompleteExample 2022-08-24T04:31:45Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:45Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 4s [id=sgrule-4291077335]
-TestTerraformCompleteExample 2022-08-24T04:31:45Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creating...
-TestTerraformCompleteExample 2022-08-24T04:31:46Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 5s [id=sgrule-2855636631]
-TestTerraformCompleteExample 2022-08-24T04:31:47Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creation complete after 5s [id=sgrule-2906395109]
-TestTerraformCompleteExample 2022-08-24T04:31:48Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creation complete after 6s [id=sgrule-3056115592]
-TestTerraformCompleteExample 2022-08-24T04:31:48Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 7s [id=sgrule-3157588330]
-TestTerraformCompleteExample 2022-08-24T04:31:49Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 8s [id=sgrule-2373734040]
-TestTerraformCompleteExample 2022-08-24T04:31:50Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 7s [id=sgrule-1277621346]
-TestTerraformCompleteExample 2022-08-24T04:31:51Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creation complete after 7s [id=sgrule-3872560218]
-TestTerraformCompleteExample 2022-08-24T04:31:51Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creation complete after 7s [id=sgrule-143417820]
-TestTerraformCompleteExample 2022-08-24T04:31:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 8s [id=sgrule-2430641094]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creation complete after 7s [id=sgrule-1305111690]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: Apply complete! Resources: 18 added, 0 changed, 0 destroyed.
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: Outputs:
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "egress-all-to-public-internet",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: auto_group_egress_to_public_internet_rule_ids = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "sgrule-2629990382",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: auto_group_ingress_all_from_self_rule_ids = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "sgrule-2629990382",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "egress-all-to-public-internet",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: computed_egress_rule_ids = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "sgrule-1277621346",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: computed_ingress_rule_ids = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "sgrule-4291077335",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: computed_managed_egress_rule_ids = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "sgrule-3157588330",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: computed_managed_ingress_rule_ids = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "sgrule-1236050544",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: disabled_sg_id = "I was not created"
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: egress_rule_keys = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "egress-all-all-all-to-self",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "egress-all-all-icmp-to-sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ingress_rule_keys = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "ingress-all-all-all-from-self",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "ingress-all-all-icmp-from-sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: managed_egress_rule_keys = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "egress-ssh-tcp-to-pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: managed_ingress_rule_keys = [
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66:   "ingress-ssh-tcp-from-pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:53Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:54Z logger.go:66: ["ingress-all-all-all-from-self","ingress-all-all-icmp-from-sg-b551fece"]
-TestTerraformCompleteExample 2022-08-24T04:31:54Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:54Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:55Z logger.go:66: ["egress-all-all-all-to-self","egress-all-all-icmp-to-sg-b551fece"]
-TestTerraformCompleteExample 2022-08-24T04:31:55Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:55Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:55Z logger.go:66: ["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-68a54001"]
-TestTerraformCompleteExample 2022-08-24T04:31:55Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:55Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:31:56Z logger.go:66: ["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-68a54001"]
-TestTerraformCompleteExample 2022-08-24T04:31:56Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:31:56Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:31:57Z logger.go:66: ["sgrule-1277621346"]
-TestTerraformCompleteExample 2022-08-24T04:31:57Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:31:57Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:31:58Z logger.go:66: ["sgrule-4291077335"]
-TestTerraformCompleteExample 2022-08-24T04:31:58Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:31:58Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:31:59Z logger.go:66: ["sgrule-3157588330"]
-TestTerraformCompleteExample 2022-08-24T04:31:59Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:31:59Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformCompleteExample 2022-08-24T04:32:00Z logger.go:66: ["sgrule-1236050544"]
-TestTerraformCompleteExample 2022-08-24T04:32:00Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:32:00Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformCompleteExample 2022-08-24T04:32:00Z logger.go:66: ["egress-all-to-public-internet"]
-TestTerraformCompleteExample 2022-08-24T04:32:00Z retry.go:91: terraform [output -no-color -json disabled_sg_id]
-TestTerraformCompleteExample 2022-08-24T04:32:00Z logger.go:66: Running command terraform with args [output -no-color -json disabled_sg_id]
-TestTerraformCompleteExample 2022-08-24T04:32:01Z logger.go:66: "I was not created"
-TestTerraformCompleteExample 2022-08-24T04:32:01Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T04:32:01Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T04:32:04Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-24T04:32:04Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-24T04:32:04Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-03a9f28ccfc1df4e0]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-0782597d1bd129a61]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-072c7b65ef1be3afa]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1236050544]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-4291077335]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-1305111690]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-143417820]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-2430641094]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-2906395109]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-2373734040]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-2855636631]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Refreshing state... [id=sgrule-2629990382]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-3056115592]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-2348133159]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-2025826228]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-3872560218]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-3157588330]
-TestTerraformCompleteExample 2022-08-24T04:32:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1277621346]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - destroy
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - address_family = "IPv4" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:326504147071:prefix-list/pl-072c7b65ef1be3afa" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id             = "pl-072c7b65ef1be3afa" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - max_entries    = 5 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - name           = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - owner_id       = "326504147071" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - tags           = {} -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - tags_all       = {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - version        = 1 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - entry {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - description = "Primary" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # aws_security_group.other will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group" "other" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0782597d1bd129a61" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description            = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - egress                 = [] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                     = "sg-0782597d1bd129a61" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - ingress                = [] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - name                   = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - tags                   = {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "Name" = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - tags_all               = {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "Name"       = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description            = "ex-complete" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - egress                 = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "::/0",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = ""
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 80
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "pl-072c7b65ef1be3afa",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 80
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "egress-all-all-all-to-self"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = true
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = -1
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = -1
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 5432
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 5432
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 22
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 22
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "pl-072c7b65ef1be3afa",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                     = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - ingress                = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = ""
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 80
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "sg-0782597d1bd129a61",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 80
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "sg-0782597d1bd129a61",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "ingress-all-all-all-from-self"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = true
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = -1
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = -1
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 5432
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 5432
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - from_port        = 22
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                   - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:               - to_port          = 22
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - name                   = "ex-complete" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - tags                   = {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "Name" = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - tags_all               = {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "Name"       = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - timeouts {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - create = "10m" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - delete = "15m" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-2629990382" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "::/0",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 80 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-1277621346" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "pl-072c7b65ef1be3afa",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 80 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port                = 80 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                       = "sgrule-4291077335" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id        = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - source_security_group_id = "sg-0782597d1bd129a61" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port                  = 80 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "https-443-tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-3157588330" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "pl-072c7b65ef1be3afa",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description              = "https-443-tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port                = 443 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                       = "sgrule-1236050544" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id        = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - source_security_group_id = "sg-0782597d1bd129a61" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port                  = 443 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-2348133159" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-2025826228" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-68a54001" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-3872560218" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-2855636631" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-2373734040" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-68a54001" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-3056115592" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:           - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-2430641094" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = true -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                       = "sgrule-1305111690" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id        = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type                     = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description       = "ingress-all-all-all-from-self" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                = "sgrule-2906395109" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self              = true -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - id                       = "sgrule-143417820" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - security_group_id        = "sg-03a9f28ccfc1df4e0" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66: Plan: 0 to add, 0 to change, 18 to destroy.
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66: Changes to Outputs:
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "egress-all-to-public-internet",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - auto_group_egress_to_public_internet_rule_ids      = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "sgrule-2629990382",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - auto_group_ingress_all_from_self_rule_ids          = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "sgrule-2629990382",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys         = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "egress-all-to-public-internet",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - computed_egress_rule_ids                           = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "sgrule-1277621346",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - computed_ingress_rule_ids                          = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "sgrule-4291077335",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - computed_managed_egress_rule_ids                   = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "sgrule-3157588330",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - computed_managed_ingress_rule_ids                  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "sgrule-1236050544",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - disabled_sg_id                                     = "I was not created" -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - egress_rule_keys                                   = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "egress-all-all-all-to-self",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "egress-all-all-icmp-to-sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - ingress_rule_keys                                  = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "ingress-all-all-all-from-self",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "ingress-all-all-icmp-from-sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - managed_egress_rule_keys                           = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "egress-ssh-tcp-to-pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:   - managed_ingress_rule_keys                          = [
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:       - "ingress-ssh-tcp-from-pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T04:32:06Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-2855636631]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-2025826228]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-143417820]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-2430641094]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-3157588330]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-1277621346]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-2348133159]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-1305111690]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-3056115592]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-1236050544]
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-24T04:32:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destroying... [id=sgrule-2906395109]
-TestTerraformCompleteExample 2022-08-24T04:32:08Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 2s
-TestTerraformCompleteExample 2022-08-24T04:32:08Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Destroying... [id=sgrule-2629990382]
-TestTerraformCompleteExample 2022-08-24T04:32:10Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 4s
-TestTerraformCompleteExample 2022-08-24T04:32:10Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-4291077335]
-TestTerraformCompleteExample 2022-08-24T04:32:11Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destruction complete after 4s
-TestTerraformCompleteExample 2022-08-24T04:32:11Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-2373734040]
-TestTerraformCompleteExample 2022-08-24T04:32:11Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destruction complete after 5s
-TestTerraformCompleteExample 2022-08-24T04:32:11Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-3872560218]
-TestTerraformCompleteExample 2022-08-24T04:32:12Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 6s
-TestTerraformCompleteExample 2022-08-24T04:32:13Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destruction complete after 6s
-TestTerraformCompleteExample 2022-08-24T04:32:14Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T04:32:14Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 8s
-TestTerraformCompleteExample 2022-08-24T04:32:14Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-072c7b65ef1be3afa]
-TestTerraformCompleteExample 2022-08-24T04:32:15Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 8s
-TestTerraformCompleteExample 2022-08-24T04:32:16Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destruction complete after 8s
-TestTerraformCompleteExample 2022-08-24T04:32:16Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-to-public-internet"]: Destruction complete after 8s
-TestTerraformCompleteExample 2022-08-24T04:32:17Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 6s
-TestTerraformCompleteExample 2022-08-24T04:32:17Z logger.go:66: aws_security_group.other: Destroying... [id=sg-0782597d1bd129a61]
-TestTerraformCompleteExample 2022-08-24T04:32:17Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T04:32:18Z logger.go:66: aws_security_group.other: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-24T04:32:18Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T04:32:18Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-03a9f28ccfc1df4e0]
-TestTerraformCompleteExample 2022-08-24T04:32:19Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-24T04:32:22Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T04:32:22Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T04:32:22Z logger.go:66: Destroy complete! Resources: 18 destroyed.
---- PASS: TestTerraformCompleteExample (48.69s)
-PASS
-ok  	command-line-arguments	48.708s
+TestTerraformCompleteExample 2022-08-24T14:34:38Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:38Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformCompleteExample 2022-08-24T14:34:39Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:39Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformCompleteExample 2022-08-24T14:34:39Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: [0m[32m
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: should now work.
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformCompleteExample 2022-08-24T14:34:40Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T14:34:40Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:42Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    apply.go:15:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_complete_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformCompleteExample
+TestTerraformCompleteExample 2022-08-24T14:34:42Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T14:34:42Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: An input variable with the name
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCompleteExample 2022-08-24T14:34:44Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformCompleteExample 2022-08-24T14:34:44Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    destroy.go:11:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
+        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
+        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
+        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_complete_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformCompleteExample
+--- FAIL: TestTerraformCompleteExample (6.18s)
+FAIL
+FAIL	command-line-arguments	6.199s
+FAIL

--- a/test/terraform_complete_test.log
+++ b/test/terraform_complete_test.log
@@ -1,1026 +1,1051 @@
 === RUN   TestTerraformCompleteExample
-TestTerraformCompleteExample 2022-08-24T15:14:55Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:14:55Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformCompleteExample 2022-08-24T15:14:56Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:14:56Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformCompleteExample 2022-08-24T15:14:56Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: [0m[32m
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: should now work.
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformCompleteExample 2022-08-24T15:14:57Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T15:14:57Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T15:14:59Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-24T15:14:59Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + create
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + address_family = "IPv4"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + arn            = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id             = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + max_entries    = 5
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name           = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + owner_id       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags_all       = {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + version        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + entry {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + cidr        = "172.31.0.0/16"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + description = "Primary"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # aws_security_group.other will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group" "other" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description            = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name                   = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags                   = {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name" = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags_all               = {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name"       = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description            = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name                   = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags                   = {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name" = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + tags_all               = {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "Name"       = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + timeouts {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + create = "10m"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + delete = "15m"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "::/0",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "Opening up ingress all ports from self security group."
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = true
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 80
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 80
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 80
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 80
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 22
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 22
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = 22
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:           + "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = 22
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-all-all-all-to-self"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = true
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = true
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be created
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + from_port                = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + to_port                  = -1
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Plan: 19 to add, 0 to change, 0 to destroy.
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66: Changes to Outputs:
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_egress_rule_ids                                = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_ingress_rule_ids                               = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_managed_egress_rule_ids                        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + computed_managed_ingress_rule_ids                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + disabled_sg_id                                          = "I was not created"
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + egress_rule_keys                                        = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + ingress_rule_keys                                       = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + managed_egress_rule_keys                                = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:00Z logger.go:66:   + managed_ingress_rule_keys                               = (known after apply)
-TestTerraformCompleteExample 2022-08-24T15:15:01Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:01Z logger.go:66: aws_security_group.other: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:01Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:02Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-0027f2e7276e6b628]
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-088f339996d8a12c1]
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-0ce9760dd7fd54d43]
-TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 1s [id=sgrule-1297727356]
-TestTerraformCompleteExample 2022-08-24T15:15:04Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:05Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Creation complete after 2s [id=sgrule-251523704]
-TestTerraformCompleteExample 2022-08-24T15:15:05Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:06Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creation complete after 2s [id=sgrule-2314322188]
-TestTerraformCompleteExample 2022-08-24T15:15:06Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:06Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 3s [id=sgrule-3316891827]
-TestTerraformCompleteExample 2022-08-24T15:15:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creation complete after 4s [id=sgrule-1184747838]
-TestTerraformCompleteExample 2022-08-24T15:15:07Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:08Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 4s [id=sgrule-1378512088]
-TestTerraformCompleteExample 2022-08-24T15:15:08Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-24T15:15:09Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 5s [id=sgrule-1114986369]
-TestTerraformCompleteExample 2022-08-24T15:15:09Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 6s [id=sgrule-1256776488]
-TestTerraformCompleteExample 2022-08-24T15:15:10Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creation complete after 7s [id=sgrule-3451758508]
-TestTerraformCompleteExample 2022-08-24T15:15:11Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 7s [id=sgrule-3694565669]
-TestTerraformCompleteExample 2022-08-24T15:15:12Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creation complete after 7s [id=sgrule-1492769384]
-TestTerraformCompleteExample 2022-08-24T15:15:13Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 8s [id=sgrule-1316103192]
-TestTerraformCompleteExample 2022-08-24T15:15:14Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creation complete after 7s [id=sgrule-3267436176]
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 7s [id=sgrule-3333521439]
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 8s [id=sgrule-4133694951]
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: Error: [WARN] A duplicate Security Group rule was found on (sg-088f339996d8a12c1). This may be
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: a side effect of a now-fixed Terraform issue causing two security groups with
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: identical attributes but different source_security_group_ids to overwrite each
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: sg-088f339996d8a12c1, ALL, ALLOW" already exists
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: 	status code: 400, request id: aabc3d09-09dd-42a4-b604-6a731bdcb613
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:   with module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"],
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:   on ../../custom_rules.tf line 63, in resource "aws_security_group_rule" "rules":
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:   63: resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:15Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: [WARN] A duplicate Security Group rule was found on (sg-088f339996d8a12c1). This may be
-a side effect of a now-fixed Terraform issue causing two security groups with
-identical attributes but different source_security_group_ids to overwrite each
-other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
-information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: sg-088f339996d8a12c1, ALL, ALLOW" already exists
-	status code: 400, request id: aabc3d09-09dd-42a4-b604-6a731bdcb613
-
-  with module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"],
-  on ../../custom_rules.tf line 63, in resource "aws_security_group_rule" "rules":
-  63: resource "aws_security_group_rule" "rules" {
-}
-    apply.go:15:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_complete_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: [WARN] A duplicate Security Group rule was found on (sg-088f339996d8a12c1). This may be
-        	            	a side effect of a now-fixed Terraform issue causing two security groups with
-        	            	identical attributes but different source_security_group_ids to overwrite each
-        	            	other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
-        	            	information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: sg-088f339996d8a12c1, ALL, ALLOW" already exists
-        	            		status code: 400, request id: aabc3d09-09dd-42a4-b604-6a731bdcb613
-
-        	            	  with module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"],
-        	            	  on ../../custom_rules.tf line 63, in resource "aws_security_group_rule" "rules":
-        	            	  63: resource "aws_security_group_rule" "rules" {
-        	            	}
-        	Test:       	TestTerraformCompleteExample
-TestTerraformCompleteExample 2022-08-24T15:15:15Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T15:15:15Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-24T15:15:18Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-24T15:15:18Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-24T15:15:18Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-0ce9760dd7fd54d43]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-088f339996d8a12c1]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-0027f2e7276e6b628]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-4133694951]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-3333521439]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1378512088]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Refreshing state... [id=sgrule-2314322188]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1316103192]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-3451758508]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1297727356]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-3694565669]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-3267436176]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-251523704]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-1492769384]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1114986369]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-1184747838]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1256776488]
-TestTerraformCompleteExample 2022-08-24T15:15:19Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-3316891827]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - destroy
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - address_family = "IPv4" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:326504147071:prefix-list/pl-0027f2e7276e6b628" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id             = "pl-0027f2e7276e6b628" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - max_entries    = 5 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - name           = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - owner_id       = "326504147071" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags           = {} -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags_all       = {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - version        = 1 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - entry {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - description = "Primary" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # aws_security_group.other will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group" "other" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0ce9760dd7fd54d43" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description            = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - egress                 = [] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                     = "sg-0ce9760dd7fd54d43" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ingress                = [] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - name                   = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags                   = {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name" = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags_all               = {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name"       = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description            = "ex-complete" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - egress                 = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "::/0",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = ""
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 80
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-0027f2e7276e6b628",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 80
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-all-all-all-to-self"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = true
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = -1
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = -1
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 22
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 22
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-0027f2e7276e6b628",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                     = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ingress                = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = ""
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 80
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-0ce9760dd7fd54d43",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 80
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "Opening up ingress all ports from self security group."
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = true
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-0ce9760dd7fd54d43",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-b551fece"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = -1
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "sg-b551fece",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = -1
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 5432
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-68a54001"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - from_port        = 22
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                   - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:               - to_port          = 22
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - name                   = "ex-complete" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags                   = {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name" = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - tags_all               = {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "Name"       = "ex-complete"
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - timeouts {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - create = "10m" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - delete = "15m" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-2314322188" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "::/0",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_ingress_all_from_self_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "Opening up ingress all ports from self security group." -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-251523704" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = true -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 80 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3316891827" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-0027f2e7276e6b628",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 80 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = 80 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-3333521439" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-0ce9760dd7fd54d43" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = 80 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "https-443-tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1256776488" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-0027f2e7276e6b628",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description              = "https-443-tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = 443 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-4133694951" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-0ce9760dd7fd54d43" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = 443 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1297727356" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1316103192" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-68a54001" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3267436176" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3694565669" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1378512088" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-68a54001" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-3451758508" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:           - "pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                = "sgrule-1114986369" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self              = true -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-1492769384" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "egress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be destroyed
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - id                       = "sgrule-1184747838" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - security_group_id        = "sg-088f339996d8a12c1" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Plan: 0 to add, 0 to change, 18 to destroy.
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66: Changes to Outputs:
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-all-all-to-public-internet",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-all-all-from-self",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_egress_rule_ids                                = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-3316891827",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_ingress_rule_ids                               = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-3333521439",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_managed_egress_rule_ids                        = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-1256776488",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "sgrule-4133694951",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - disabled_sg_id                                          = "I was not created" -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - managed_egress_rule_keys                                = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "egress-ssh-tcp-to-pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:   - managed_ingress_rule_keys                               = [
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:       - "ingress-ssh-tcp-from-pl-68a54001",
-TestTerraformCompleteExample 2022-08-24T15:15:20Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1378512088]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-3316891827]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-1492769384]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-3267436176]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Destroying... [id=sgrule-251523704]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-3451758508]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1316103192]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-4133694951]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destroying... [id=sgrule-2314322188]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-1184747838]
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-24T15:15:21Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-3694565669]
-TestTerraformCompleteExample 2022-08-24T15:15:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-24T15:15:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-3333521439]
-TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destruction complete after 2s
-TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1297727356]
-TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destruction complete after 3s
-TestTerraformCompleteExample 2022-08-24T15:15:23Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-1114986369]
-TestTerraformCompleteExample 2022-08-24T15:15:24Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destruction complete after 3s
-TestTerraformCompleteExample 2022-08-24T15:15:24Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-1256776488]
-TestTerraformCompleteExample 2022-08-24T15:15:24Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 4s
-TestTerraformCompleteExample 2022-08-24T15:15:25Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_ingress_all_from_self_rules["ingress-all-all-from-self"]: Destruction complete after 5s
-TestTerraformCompleteExample 2022-08-24T15:15:26Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 5s
-TestTerraformCompleteExample 2022-08-24T15:15:27Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destruction complete after 6s
-TestTerraformCompleteExample 2022-08-24T15:15:27Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T15:15:28Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 6s
-TestTerraformCompleteExample 2022-08-24T15:15:28Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T15:15:28Z logger.go:66: aws_security_group.other: Destroying... [id=sg-0ce9760dd7fd54d43]
-TestTerraformCompleteExample 2022-08-24T15:15:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T15:15:30Z logger.go:66: aws_security_group.other: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-24T15:15:30Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 6s
-TestTerraformCompleteExample 2022-08-24T15:15:31Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T15:15:31Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-0027f2e7276e6b628]
-TestTerraformCompleteExample 2022-08-24T15:15:31Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-088f339996d8a12c1]
-TestTerraformCompleteExample 2022-08-24T15:15:32Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-24T15:15:38Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-24T15:15:38Z logger.go:66:
-TestTerraformCompleteExample 2022-08-24T15:15:38Z logger.go:66: Destroy complete! Resources: 18 destroyed.
---- FAIL: TestTerraformCompleteExample (42.89s)
-FAIL
-FAIL	command-line-arguments	42.905s
-FAIL
+TestTerraformCompleteExample 2022-08-24T15:22:26Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-24T15:22:26Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-24T15:22:26Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformCompleteExample 2022-08-24T15:22:26Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:26Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformCompleteExample 2022-08-24T15:22:26Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:26Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformCompleteExample 2022-08-24T15:22:26Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: [0m[32m
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: should now work.
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformCompleteExample 2022-08-24T15:22:27Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:22:27Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + create
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + address_family = "IPv4"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + arn            = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id             = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + max_entries    = 5
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + name           = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + owner_id       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + tags_all       = {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + version        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + entry {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + cidr        = "172.31.0.0/16"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + description = "Primary"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # aws_security_group.other will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group" "other" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description            = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + name                   = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "Name" = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "Name"       = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description            = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + name                   = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "Name" = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "Name"       = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + timeouts {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + create = "10m"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + delete = "15m"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "::/0",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 80
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 80
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 80
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 80
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 5432
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 5432
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 22
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 22
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 5432
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 5432
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = 22
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:           + "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = 22
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = true
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = true
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be created
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + from_port                = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + to_port                  = -1
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: Plan: 18 to add, 0 to change, 0 to destroy.
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66: Changes to Outputs:
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = []
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + computed_egress_rule_ids                                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + computed_ingress_rule_ids                               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + computed_managed_egress_rule_ids                        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + computed_managed_ingress_rule_ids                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + disabled_sg_id                                          = "I was not created"
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + egress_rule_keys                                        = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + ingress_rule_keys                                       = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + managed_egress_rule_keys                                = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:31Z logger.go:66:   + managed_ingress_rule_keys                               = (known after apply)
+TestTerraformCompleteExample 2022-08-24T15:22:33Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:33Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:33Z logger.go:66: aws_security_group.other: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:34Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-0731df5829e3557f3]
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-0682dc631396ab174]
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-062aa0634f2a1f37e]
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:35Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:36Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 1s [id=sgrule-2132832927]
+TestTerraformCompleteExample 2022-08-24T15:22:36Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:37Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creation complete after 2s [id=sgrule-2529438771]
+TestTerraformCompleteExample 2022-08-24T15:22:37Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:38Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creation complete after 3s [id=sgrule-1787019858]
+TestTerraformCompleteExample 2022-08-24T15:22:38Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:39Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 4s [id=sgrule-1254590109]
+TestTerraformCompleteExample 2022-08-24T15:22:39Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:39Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 5s [id=sgrule-566700045]
+TestTerraformCompleteExample 2022-08-24T15:22:39Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-24T15:22:40Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 6s [id=sgrule-3392268965]
+TestTerraformCompleteExample 2022-08-24T15:22:41Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 7s [id=sgrule-212313000]
+TestTerraformCompleteExample 2022-08-24T15:22:42Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creation complete after 8s [id=sgrule-1628577933]
+TestTerraformCompleteExample 2022-08-24T15:22:43Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 8s [id=sgrule-1373622181]
+TestTerraformCompleteExample 2022-08-24T15:22:44Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 9s [id=sgrule-721179194]
+TestTerraformCompleteExample 2022-08-24T15:22:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creation complete after 9s [id=sgrule-1868671803]
+TestTerraformCompleteExample 2022-08-24T15:22:45Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Creation complete after 9s [id=sgrule-2954509289]
+TestTerraformCompleteExample 2022-08-24T15:22:46Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creation complete after 9s [id=sgrule-2042428339]
+TestTerraformCompleteExample 2022-08-24T15:22:47Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 9s [id=sgrule-2470478149]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 8s [id=sgrule-2054541780]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: Apply complete! Resources: 18 added, 0 changed, 0 destroyed.
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: Outputs:
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "egress-all-all-to-public-internet",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: auto_group_ingress_http_from_public_internet_rule_keys = []
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: computed_egress_rule_ids = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "sgrule-212313000",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: computed_ingress_rule_ids = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "sgrule-2470478149",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: computed_managed_egress_rule_ids = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "sgrule-1254590109",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: computed_managed_ingress_rule_ids = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "sgrule-2054541780",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: disabled_sg_id = "I was not created"
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: egress_rule_keys = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "egress-all-all-all-to-self",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "egress-all-all-icmp-to-sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ingress_rule_keys = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "ingress-all-all-all-from-self",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "ingress-all-all-icmp-from-sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: managed_egress_rule_keys = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "egress-ssh-tcp-to-pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: managed_ingress_rule_keys = [
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66:   "ingress-ssh-tcp-from-pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:48Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:49Z logger.go:66: ["ingress-all-all-all-from-self","ingress-all-all-icmp-from-sg-b551fece"]
+TestTerraformCompleteExample 2022-08-24T15:22:49Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:49Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:50Z logger.go:66: ["egress-all-all-all-to-self","egress-all-all-icmp-to-sg-b551fece"]
+TestTerraformCompleteExample 2022-08-24T15:22:50Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:50Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:50Z logger.go:66: ["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-68a54001"]
+TestTerraformCompleteExample 2022-08-24T15:22:50Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:50Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:51Z logger.go:66: ["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-68a54001"]
+TestTerraformCompleteExample 2022-08-24T15:22:51Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:51Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:52Z logger.go:66: ["sgrule-212313000"]
+TestTerraformCompleteExample 2022-08-24T15:22:52Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:52Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:53Z logger.go:66: ["sgrule-2470478149"]
+TestTerraformCompleteExample 2022-08-24T15:22:53Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:53Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:54Z logger.go:66: ["sgrule-1254590109"]
+TestTerraformCompleteExample 2022-08-24T15:22:54Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:54Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformCompleteExample 2022-08-24T15:22:55Z logger.go:66: ["sgrule-2054541780"]
+TestTerraformCompleteExample 2022-08-24T15:22:55Z retry.go:91: terraform [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:55Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:55Z logger.go:66: []
+TestTerraformCompleteExample 2022-08-24T15:22:55Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:55Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformCompleteExample 2022-08-24T15:22:56Z logger.go:66: ["egress-all-all-to-public-internet"]
+TestTerraformCompleteExample 2022-08-24T15:22:56Z retry.go:91: terraform [output -no-color -json disabled_sg_id]
+TestTerraformCompleteExample 2022-08-24T15:22:56Z logger.go:66: Running command terraform with args [output -no-color -json disabled_sg_id]
+TestTerraformCompleteExample 2022-08-24T15:22:57Z logger.go:66: "I was not created"
+TestTerraformCompleteExample 2022-08-24T15:22:57Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:22:57Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 1s [id=pl-68a54001]
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-0731df5829e3557f3]
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-062aa0634f2a1f37e]
+TestTerraformCompleteExample 2022-08-24T15:23:00Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-0682dc631396ab174]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Refreshing state... [id=sgrule-2954509289]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-721179194]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1373622181]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-566700045]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-2042428339]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-1868671803]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-2132832927]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-2470478149]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-2054541780]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-1628577933]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-1787019858]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-2529438771]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-3392268965]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1254590109]
+TestTerraformCompleteExample 2022-08-24T15:23:01Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-212313000]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - destroy
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - address_family = "IPv4" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:326504147071:prefix-list/pl-0731df5829e3557f3" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id             = "pl-0731df5829e3557f3" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - max_entries    = 5 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - name           = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - owner_id       = "326504147071" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - tags           = {} -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - tags_all       = {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - version        = 1 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - entry {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - description = "Primary" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # aws_security_group.other will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group" "other" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-062aa0634f2a1f37e" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description            = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - egress                 = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                     = "sg-062aa0634f2a1f37e" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - ingress                = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - name                   = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "Name" = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "Name"       = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description            = "ex-complete" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - egress                 = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "::/0",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = ""
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 80
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "pl-0731df5829e3557f3",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 80
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = true
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = -1
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = -1
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 5432
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 5432
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 22
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 22
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "pl-0731df5829e3557f3",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                     = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - ingress                = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = ""
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 80
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "sg-062aa0634f2a1f37e",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 80
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "sg-062aa0634f2a1f37e",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = true
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-b551fece"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = -1
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = -1
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 5432
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 5432
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-68a54001"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - from_port        = 22
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                   - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:               - to_port          = 22
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - name                   = "ex-complete" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - tags                   = {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "Name" = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - tags_all               = {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "Name"       = "ex-complete"
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - timeouts {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - create = "10m" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - delete = "15m" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "auto_group_egress_all_to_public_internet_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-2954509289" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "::/0",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-212313000" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "pl-0731df5829e3557f3",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port                = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                       = "sgrule-2470478149" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id        = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - source_security_group_id = "sg-062aa0634f2a1f37e" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port                  = 80 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "https-443-tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-1254590109" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "pl-0731df5829e3557f3",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description              = "https-443-tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port                = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                       = "sgrule-2054541780" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id        = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - source_security_group_id = "sg-062aa0634f2a1f37e" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port                  = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-1373622181" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-2132832927" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-68a54001" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-2042428339" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-721179194" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-566700045" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-68a54001" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-1868671803" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:           - "pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-3392268965" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = true -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                       = "sgrule-1628577933" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id        = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type                     = "egress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description       = "ingress-all-all-all-from-self" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                = "sgrule-1787019858" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self              = true -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be destroyed
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - id                       = "sgrule-2529438771" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - security_group_id        = "sg-0682dc631396ab174" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66: Plan: 0 to add, 0 to change, 18 to destroy.
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66: Changes to Outputs:
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "egress-all-all-to-public-internet",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - computed_egress_rule_ids                                = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "sgrule-212313000",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - computed_ingress_rule_ids                               = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "sgrule-2470478149",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - computed_managed_egress_rule_ids                        = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "sgrule-1254590109",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "sgrule-2054541780",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - disabled_sg_id                                          = "I was not created" -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - egress_rule_keys                                        = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "egress-all-all-all-to-self",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "egress-all-all-icmp-to-sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - ingress_rule_keys                                       = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "ingress-all-all-all-from-self",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "ingress-all-all-icmp-from-sg-b551fece",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - managed_egress_rule_keys                                = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "egress-ssh-tcp-to-pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:   - managed_ingress_rule_keys                               = [
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:       - "ingress-ssh-tcp-from-pl-68a54001",
+TestTerraformCompleteExample 2022-08-24T15:23:02Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-2132832927]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destroying... [id=sgrule-2954509289]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-2529438771]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-1628577933]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-212313000]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destroying... [id=sgrule-1787019858]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-1868671803]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-721179194]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-2054541780]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-566700045]
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:23:03Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-2042428339]
+TestTerraformCompleteExample 2022-08-24T15:23:04Z logger.go:66: module.security_group.aws_security_group_rule.auto_group_egress_all_to_public_internet_rules["egress-all-all-to-public-internet"]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:23:04Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-3392268965]
+TestTerraformCompleteExample 2022-08-24T15:23:04Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destruction complete after 2s
+TestTerraformCompleteExample 2022-08-24T15:23:04Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-1254590109]
+TestTerraformCompleteExample 2022-08-24T15:23:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 3s
+TestTerraformCompleteExample 2022-08-24T15:23:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-2470478149]
+TestTerraformCompleteExample 2022-08-24T15:23:06Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destruction complete after 3s
+TestTerraformCompleteExample 2022-08-24T15:23:06Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1373622181]
+TestTerraformCompleteExample 2022-08-24T15:23:06Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destruction complete after 4s
+TestTerraformCompleteExample 2022-08-24T15:23:07Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destruction complete after 5s
+TestTerraformCompleteExample 2022-08-24T15:23:08Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 5s
+TestTerraformCompleteExample 2022-08-24T15:23:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-24T15:23:09Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:23:10Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-24T15:23:10Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:23:11Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:23:11Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-0731df5829e3557f3]
+TestTerraformCompleteExample 2022-08-24T15:23:12Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-24T15:23:12Z logger.go:66: aws_security_group.other: Destroying... [id=sg-062aa0634f2a1f37e]
+TestTerraformCompleteExample 2022-08-24T15:23:12Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:23:12Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-0682dc631396ab174]
+TestTerraformCompleteExample 2022-08-24T15:23:13Z logger.go:66: aws_security_group.other: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:23:13Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-24T15:23:18Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-24T15:23:18Z logger.go:66:
+TestTerraformCompleteExample 2022-08-24T15:23:18Z logger.go:66: Destroy complete! Resources: 18 destroyed.
+--- PASS: TestTerraformCompleteExample (52.93s)
+PASS
+ok  	command-line-arguments	52.945s

--- a/test/terraform_computed_rules_test.go
+++ b/test/terraform_computed_rules_test.go
@@ -31,6 +31,7 @@ func TestTerraformComputedRulesExample(t *testing.T) {
 	actualComputedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_ingress_rule_ids"))
 	actualComputedManagedIngressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_egress_rule_ids"))
 	actualComputedManagedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_ingress_rule_ids"))
+	actualAutoGroupIngressAllFromSelfRuleKeys := terraform.Output(t, terraformOptions, "auto_group_ingress_all_from_self_rule_keys")
 	actualAutoGroupEgressAllToPublicInternetRuleKeys := terraform.Output(t, terraformOptions, "auto_group_egress_all_to_public_internet_rule_keys")
 
 	expectedIngressRuleKeys := "[]"
@@ -41,6 +42,7 @@ func TestTerraformComputedRulesExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 1
 	expectedComputedManagedIngressRuleLength := 1
 	expectedComputedManagedEgressRuleLength := 1
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[]"
 	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[]"
 
 	assert.Equal(t, expectedIngressRuleKeys, actualIngressRuleKeys, "Map %q should match %q", expectedIngressRuleKeys, actualIngressRuleKeys)
@@ -51,5 +53,6 @@ func TestTerraformComputedRulesExample(t *testing.T) {
 	assert.Equal(t, expectedComputedEgressRuleLength, actualComputedEgressRuleLength, "Map %q should match %q", expectedComputedEgressRuleLength, actualComputedEgressRuleLength)
 	assert.Equal(t, expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength, "Map %q should match %q", expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength)
 	assert.Equal(t, expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength, "Map %q should match %q", expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength)
+	assert.Equal(t, expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys, "Map %q should match %q", expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys)
 	assert.Equal(t, expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys, "Map %q should match %q", expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys)
 }

--- a/test/terraform_computed_rules_test.log
+++ b/test/terraform_computed_rules_test.log
@@ -1,161 +1,478 @@
 === RUN   TestTerraformComputedRulesExample
-TestTerraformComputedRulesExample 2022-08-24T14:35:00Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformComputedRulesExample 2022-08-24T14:35:01Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:01Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformComputedRulesExample 2022-08-24T14:35:01Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: [0m[32m
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: should now work.
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: An input variable with the name
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: An input variable with the name
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    apply.go:15:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_computed_rules_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformComputedRulesExample
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: An input variable with the name
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: An input variable with the name
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    destroy.go:11:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
-        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
-        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
-        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_computed_rules_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformComputedRulesExample
---- FAIL: TestTerraformComputedRulesExample (6.03s)
-FAIL
-FAIL	command-line-arguments	6.046s
-FAIL
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformComputedRulesExample 2022-08-24T15:16:56Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: [0m[32m
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: should now work.
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T15:16:57Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T15:17:00Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + create
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66: Terraform will perform the following actions:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + address_family = "IPv4"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + arn            = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + id             = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + max_entries    = 5
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + name           = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + owner_id       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + tags_all       = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + version        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + entry {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + cidr        = "172.31.0.0/16"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + description = "Primary"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   # aws_security_group.other will be created
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + resource "aws_security_group" "other" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + description            = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + id                     = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + name                   = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + tags                   = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "Name" = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + tags_all               = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "Name"       = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + description            = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + id                     = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + name                   = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + tags                   = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "Name" = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + tags_all               = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + "Name"       = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + timeouts {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + create = "10m"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:           + delete = "15m"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + from_port                = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + to_port                  = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + type                     = "egress"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + from_port                = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + to_port                  = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + type                     = "ingress"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + from_port                = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + to_port                  = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + type                     = "egress"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + from_port                = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + to_port                  = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:       + type                     = "ingress"
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66: Plan: 7 to add, 0 to change, 0 to destroy.
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66: Changes to Outputs:
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + computed_egress_rule_ids                                = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + computed_ingress_rule_ids                               = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + computed_managed_egress_rule_ids                        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + computed_managed_ingress_rule_ids                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + egress_rule_keys                                        = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + ingress_rule_keys                                       = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + managed_egress_rule_keys                                = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:01Z logger.go:66:   + managed_ingress_rule_keys                               = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:02Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-24T15:17:02Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
+TestTerraformComputedRulesExample 2022-08-24T15:17:02Z logger.go:66: aws_security_group.other: Creating...
+TestTerraformComputedRulesExample 2022-08-24T15:17:03Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-0c20dde7f83785486]
+TestTerraformComputedRulesExample 2022-08-24T15:17:04Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-048c90cc78ba719b0]
+TestTerraformComputedRulesExample 2022-08-24T15:17:04Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-0e325bb0e97fd9e86]
+TestTerraformComputedRulesExample 2022-08-24T15:17:04Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-24T15:17:04Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-24T15:17:04Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-24T15:17:04Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-24T15:17:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 1s [id=sgrule-3753907564]
+TestTerraformComputedRulesExample 2022-08-24T15:17:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 2s [id=sgrule-3895611692]
+TestTerraformComputedRulesExample 2022-08-24T15:17:06Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 3s [id=sgrule-2662239063]
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 4s [id=sgrule-3275178297]
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: Outputs:
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: auto_group_ingress_http_from_public_internet_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: computed_egress_rule_ids = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66:   "sgrule-3753907564",
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: computed_ingress_rule_ids = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66:   "sgrule-3895611692",
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: computed_managed_egress_rule_ids = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66:   "sgrule-2662239063",
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: computed_managed_ingress_rule_ids = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66:   "sgrule-3275178297",
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: egress_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: ingress_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: managed_egress_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: managed_ingress_rule_keys = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:07Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:08Z logger.go:66: []
+TestTerraformComputedRulesExample 2022-08-24T15:17:08Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:08Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:09Z logger.go:66: []
+TestTerraformComputedRulesExample 2022-08-24T15:17:09Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:09Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:10Z logger.go:66: []
+TestTerraformComputedRulesExample 2022-08-24T15:17:10Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:10Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:11Z logger.go:66: []
+TestTerraformComputedRulesExample 2022-08-24T15:17:11Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:11Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:12Z logger.go:66: ["sgrule-3753907564"]
+TestTerraformComputedRulesExample 2022-08-24T15:17:12Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:12Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:12Z logger.go:66: ["sgrule-3895611692"]
+TestTerraformComputedRulesExample 2022-08-24T15:17:12Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:12Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:13Z logger.go:66: ["sgrule-2662239063"]
+TestTerraformComputedRulesExample 2022-08-24T15:17:13Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:13Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformComputedRulesExample 2022-08-24T15:17:14Z logger.go:66: ["sgrule-3275178297"]
+TestTerraformComputedRulesExample 2022-08-24T15:17:14Z retry.go:91: terraform [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:14Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:15Z logger.go:66: []
+TestTerraformComputedRulesExample 2022-08-24T15:17:15Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:15Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformComputedRulesExample 2022-08-24T15:17:16Z logger.go:66: []
+TestTerraformComputedRulesExample 2022-08-24T15:17:16Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T15:17:16Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T15:17:19Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-048c90cc78ba719b0]
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-0e325bb0e97fd9e86]
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-0c20dde7f83785486]
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-3275178297]
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-3895611692]
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-3753907564]
+TestTerraformComputedRulesExample 2022-08-24T15:17:20Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-2662239063]
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - destroy
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66: Terraform will perform the following actions:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - address_family = "IPv4" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:326504147071:prefix-list/pl-0c20dde7f83785486" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - id             = "pl-0c20dde7f83785486" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - max_entries    = 5 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - name           = "ex-computed-rules-other" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - owner_id       = "326504147071" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - tags           = {} -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - tags_all       = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - version        = 1 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - entry {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - description = "Primary" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   # aws_security_group.other will be destroyed
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - resource "aws_security_group" "other" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-048c90cc78ba719b0" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - description            = "ex-computed-rules-other" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - egress                 = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - id                     = "sg-048c90cc78ba719b0" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - ingress                = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - name                   = "ex-computed-rules-other" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - tags                   = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "Name" = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - tags_all               = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "Name"       = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0e325bb0e97fd9e86" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - description            = "ex-computed-rules" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - egress                 = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - description      = ""
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - from_port        = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                   - "pl-0c20dde7f83785486",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - security_groups  = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - to_port          = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - from_port        = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                   - "pl-0c20dde7f83785486",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - security_groups  = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - to_port          = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - id                     = "sg-0e325bb0e97fd9e86" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - ingress                = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - description      = ""
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - from_port        = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - security_groups  = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                   - "sg-048c90cc78ba719b0",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - to_port          = 80
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - from_port        = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - security_groups  = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                   - "sg-048c90cc78ba719b0",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:               - to_port          = 443
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - name                   = "ex-computed-rules" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - tags                   = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "Name" = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - tags_all               = {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "Name"       = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - timeouts {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - create = "10m" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - delete = "15m" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - from_port         = 80 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - id                = "sgrule-3753907564" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "pl-0c20dde7f83785486",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - security_group_id = "sg-0e325bb0e97fd9e86" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - self              = false -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - to_port           = 80 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - type              = "egress" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - from_port                = 80 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - id                       = "sgrule-3895611692" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - security_group_id        = "sg-0e325bb0e97fd9e86" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - self                     = false -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - source_security_group_id = "sg-048c90cc78ba719b0" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - to_port                  = 80 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - description       = "https-443-tcp" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - id                = "sgrule-2662239063" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:           - "pl-0c20dde7f83785486",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - security_group_id = "sg-0e325bb0e97fd9e86" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - self              = false -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - type              = "egress" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - description              = "https-443-tcp" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - from_port                = 443 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - id                       = "sgrule-3275178297" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - security_group_id        = "sg-0e325bb0e97fd9e86" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - self                     = false -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - source_security_group_id = "sg-048c90cc78ba719b0" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - to_port                  = 443 -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66: Plan: 0 to add, 0 to change, 7 to destroy.
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66: Changes to Outputs:
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - computed_egress_rule_ids                                = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - "sgrule-3753907564",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - computed_ingress_rule_ids                               = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - "sgrule-3895611692",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - computed_managed_egress_rule_ids                        = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - "sgrule-2662239063",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:       - "sgrule-3275178297",
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:     ] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - egress_rule_keys                                        = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - ingress_rule_keys                                       = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - managed_egress_rule_keys                                = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:21Z logger.go:66:   - managed_ingress_rule_keys                               = [] -> null
+TestTerraformComputedRulesExample 2022-08-24T15:17:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-2662239063]
+TestTerraformComputedRulesExample 2022-08-24T15:17:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-3895611692]
+TestTerraformComputedRulesExample 2022-08-24T15:17:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-3753907564]
+TestTerraformComputedRulesExample 2022-08-24T15:17:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-3275178297]
+TestTerraformComputedRulesExample 2022-08-24T15:17:22Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 1s
+TestTerraformComputedRulesExample 2022-08-24T15:17:23Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 1s
+TestTerraformComputedRulesExample 2022-08-24T15:17:23Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 2s
+TestTerraformComputedRulesExample 2022-08-24T15:17:23Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-0c20dde7f83785486]
+TestTerraformComputedRulesExample 2022-08-24T15:17:24Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 2s
+TestTerraformComputedRulesExample 2022-08-24T15:17:24Z logger.go:66: aws_security_group.other: Destroying... [id=sg-048c90cc78ba719b0]
+TestTerraformComputedRulesExample 2022-08-24T15:17:24Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-0e325bb0e97fd9e86]
+TestTerraformComputedRulesExample 2022-08-24T15:17:25Z logger.go:66: aws_security_group.other: Destruction complete after 1s
+TestTerraformComputedRulesExample 2022-08-24T15:17:25Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformComputedRulesExample 2022-08-24T15:17:31Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
+TestTerraformComputedRulesExample 2022-08-24T15:17:31Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T15:17:31Z logger.go:66: Destroy complete! Resources: 7 destroyed.
+--- PASS: TestTerraformComputedRulesExample (35.14s)
+PASS
+ok  	command-line-arguments	35.151s

--- a/test/terraform_computed_rules_test.log
+++ b/test/terraform_computed_rules_test.log
@@ -1,475 +1,161 @@
 === RUN   TestTerraformComputedRulesExample
-TestTerraformComputedRulesExample 2022-08-24T04:33:39Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformComputedRulesExample 2022-08-24T04:33:39Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformComputedRulesExample 2022-08-24T04:33:39Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformComputedRulesExample 2022-08-24T04:33:39Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:39Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformComputedRulesExample 2022-08-24T04:33:40Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:40Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformComputedRulesExample 2022-08-24T04:33:40Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: [0m[32m
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: should now work.
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T04:33:41Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + create
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66: Terraform will perform the following actions:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + address_family = "IPv4"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + arn            = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + id             = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + max_entries    = 5
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + name           = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + owner_id       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + tags_all       = {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + version        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + entry {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + cidr        = "172.31.0.0/16"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + description = "Primary"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   # aws_security_group.other will be created
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + resource "aws_security_group" "other" {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + description            = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + id                     = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + name                   = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + tags                   = {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "Name" = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + tags_all               = {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "Name"       = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + description            = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + id                     = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + name                   = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + tags                   = {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "Name" = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + tags_all               = {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + "Name"       = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + timeouts {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + create = "10m"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:           + delete = "15m"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + from_port                = 80
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + to_port                  = 80
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + type                     = "egress"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + from_port                = 80
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + to_port                  = 80
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + type                     = "ingress"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + from_port                = 443
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + to_port                  = 443
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + type                     = "egress"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + from_port                = 443
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + to_port                  = 443
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:       + type                     = "ingress"
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66: Plan: 7 to add, 0 to change, 0 to destroy.
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66: Changes to Outputs:
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + auto_group_egress_to_public_internet_rule_ids      = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + auto_group_ingress_all_from_self_rule_ids          = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys         = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + computed_egress_rule_ids                           = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + computed_ingress_rule_ids                          = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + computed_managed_egress_rule_ids                   = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + computed_managed_ingress_rule_ids                  = (known after apply)
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + egress_rule_keys                                   = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + ingress_rule_keys                                  = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + managed_egress_rule_keys                           = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:44Z logger.go:66:   + managed_ingress_rule_keys                          = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:46Z logger.go:66: aws_security_group.other: Creating...
-TestTerraformComputedRulesExample 2022-08-24T04:33:46Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-24T04:33:46Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
-TestTerraformComputedRulesExample 2022-08-24T04:33:47Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-0f5a1ad41dae5d047]
-TestTerraformComputedRulesExample 2022-08-24T04:33:47Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-0f9d3664ff00d297b]
-TestTerraformComputedRulesExample 2022-08-24T04:33:47Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-0609f739b5538b690]
-TestTerraformComputedRulesExample 2022-08-24T04:33:47Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-24T04:33:47Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-24T04:33:47Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-24T04:33:47Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-24T04:33:48Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 1s [id=sgrule-1104802345]
-TestTerraformComputedRulesExample 2022-08-24T04:33:49Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 1s [id=sgrule-528606616]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 2s [id=sgrule-519952932]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 3s [id=sgrule-191916460]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: Outputs:
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: auto_group_egress_to_public_internet_rule_ids = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: auto_group_ingress_all_from_self_rule_ids = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: computed_egress_rule_ids = [
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66:   "sgrule-528606616",
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: computed_ingress_rule_ids = [
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66:   "sgrule-1104802345",
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: computed_managed_egress_rule_ids = [
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66:   "sgrule-191916460",
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: computed_managed_ingress_rule_ids = [
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66:   "sgrule-519952932",
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: egress_rule_keys = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: ingress_rule_keys = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: managed_egress_rule_keys = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: managed_ingress_rule_keys = []
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:50Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:51Z logger.go:66: []
-TestTerraformComputedRulesExample 2022-08-24T04:33:51Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:51Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:52Z logger.go:66: []
-TestTerraformComputedRulesExample 2022-08-24T04:33:52Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:52Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:53Z logger.go:66: []
-TestTerraformComputedRulesExample 2022-08-24T04:33:53Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:53Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:54Z logger.go:66: []
-TestTerraformComputedRulesExample 2022-08-24T04:33:54Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:54Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:55Z logger.go:66: ["sgrule-528606616"]
-TestTerraformComputedRulesExample 2022-08-24T04:33:55Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:55Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:55Z logger.go:66: ["sgrule-1104802345"]
-TestTerraformComputedRulesExample 2022-08-24T04:33:55Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:55Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:56Z logger.go:66: ["sgrule-191916460"]
-TestTerraformComputedRulesExample 2022-08-24T04:33:56Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:56Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformComputedRulesExample 2022-08-24T04:33:57Z logger.go:66: ["sgrule-519952932"]
-TestTerraformComputedRulesExample 2022-08-24T04:33:57Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:57Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformComputedRulesExample 2022-08-24T04:33:58Z logger.go:66: []
-TestTerraformComputedRulesExample 2022-08-24T04:33:58Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T04:33:58Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-24T04:34:01Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformComputedRulesExample 2022-08-24T04:34:01Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
-TestTerraformComputedRulesExample 2022-08-24T04:34:01Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-0f9d3664ff00d297b]
-TestTerraformComputedRulesExample 2022-08-24T04:34:01Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-0f5a1ad41dae5d047]
-TestTerraformComputedRulesExample 2022-08-24T04:34:01Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-0609f739b5538b690]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-519952932]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1104802345]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-191916460]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-528606616]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - destroy
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: Terraform will perform the following actions:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - address_family = "IPv4" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:326504147071:prefix-list/pl-0f5a1ad41dae5d047" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - id             = "pl-0f5a1ad41dae5d047" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - max_entries    = 5 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - name           = "ex-computed-rules-other" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - owner_id       = "326504147071" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - tags           = {} -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - tags_all       = {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - version        = 1 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - entry {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - description = "Primary" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   # aws_security_group.other will be destroyed
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - resource "aws_security_group" "other" {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0f9d3664ff00d297b" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - description            = "ex-computed-rules-other" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - egress                 = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - id                     = "sg-0f9d3664ff00d297b" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - ingress                = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - name                   = "ex-computed-rules-other" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - tags                   = {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "Name" = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - tags_all               = {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "Name"       = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0609f739b5538b690" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - description            = "ex-computed-rules" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - egress                 = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - description      = ""
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - from_port        = 80
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                   - "pl-0f5a1ad41dae5d047",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - security_groups  = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - to_port          = 80
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - from_port        = 443
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                   - "pl-0f5a1ad41dae5d047",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - security_groups  = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - to_port          = 443
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - id                     = "sg-0609f739b5538b690" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - ingress                = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - description      = ""
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - from_port        = 80
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - security_groups  = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                   - "sg-0f9d3664ff00d297b",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - to_port          = 80
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - from_port        = 443
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - security_groups  = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                   - "sg-0f9d3664ff00d297b",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:               - to_port          = 443
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - name                   = "ex-computed-rules" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - tags                   = {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "Name" = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - tags_all               = {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "Name"       = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - timeouts {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - create = "10m" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - delete = "15m" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_egress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - from_port         = 80 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - id                = "sgrule-528606616" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "pl-0f5a1ad41dae5d047",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - security_group_id = "sg-0609f739b5538b690" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - self              = false -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - to_port           = 80 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - type              = "egress" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - from_port                = 80 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - id                       = "sgrule-1104802345" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - security_group_id        = "sg-0609f739b5538b690" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - self                     = false -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - source_security_group_id = "sg-0f9d3664ff00d297b" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - to_port                  = 80 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - description       = "https-443-tcp" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - id                = "sgrule-191916460" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:           - "pl-0f5a1ad41dae5d047",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - security_group_id = "sg-0609f739b5538b690" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - self              = false -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - type              = "egress" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   # module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - description              = "https-443-tcp" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - from_port                = 443 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - id                       = "sgrule-519952932" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - security_group_id        = "sg-0609f739b5538b690" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - self                     = false -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - source_security_group_id = "sg-0f9d3664ff00d297b" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - to_port                  = 443 -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: Plan: 0 to add, 0 to change, 7 to destroy.
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66: Changes to Outputs:
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - auto_group_egress_to_public_internet_rule_ids      = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - auto_group_ingress_all_from_self_rule_ids          = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys         = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - computed_egress_rule_ids                           = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - "sgrule-528606616",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - computed_ingress_rule_ids                          = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - "sgrule-1104802345",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - computed_managed_egress_rule_ids                   = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - "sgrule-191916460",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - computed_managed_ingress_rule_ids                  = [
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:       - "sgrule-519952932",
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:     ] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - egress_rule_keys                                   = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - ingress_rule_keys                                  = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - managed_egress_rule_keys                           = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:02Z logger.go:66:   - managed_ingress_rule_keys                          = [] -> null
-TestTerraformComputedRulesExample 2022-08-24T04:34:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-528606616]
-TestTerraformComputedRulesExample 2022-08-24T04:34:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-519952932]
-TestTerraformComputedRulesExample 2022-08-24T04:34:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-191916460]
-TestTerraformComputedRulesExample 2022-08-24T04:34:03Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-1104802345]
-TestTerraformComputedRulesExample 2022-08-24T04:34:04Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 0s
-TestTerraformComputedRulesExample 2022-08-24T04:34:04Z logger.go:66: module.security_group.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 1s
-TestTerraformComputedRulesExample 2022-08-24T04:34:05Z logger.go:66: module.security_group.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 1s
-TestTerraformComputedRulesExample 2022-08-24T04:34:05Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-0f5a1ad41dae5d047]
-TestTerraformComputedRulesExample 2022-08-24T04:34:06Z logger.go:66: module.security_group.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 2s
-TestTerraformComputedRulesExample 2022-08-24T04:34:06Z logger.go:66: aws_security_group.other: Destroying... [id=sg-0f9d3664ff00d297b]
-TestTerraformComputedRulesExample 2022-08-24T04:34:06Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-0609f739b5538b690]
-TestTerraformComputedRulesExample 2022-08-24T04:34:07Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformComputedRulesExample 2022-08-24T04:34:07Z logger.go:66: aws_security_group.other: Destruction complete after 1s
-TestTerraformComputedRulesExample 2022-08-24T04:34:12Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 8s
-TestTerraformComputedRulesExample 2022-08-24T04:34:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-24T04:34:12Z logger.go:66: Destroy complete! Resources: 7 destroyed.
---- PASS: TestTerraformComputedRulesExample (33.16s)
-PASS
-ok  	command-line-arguments	33.177s
+TestTerraformComputedRulesExample 2022-08-24T14:35:00Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:00Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformComputedRulesExample 2022-08-24T14:35:01Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:01Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformComputedRulesExample 2022-08-24T14:35:01Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: [0m[32m
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: should now work.
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T14:35:02Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: An input variable with the name
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: An input variable with the name
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    apply.go:15:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_computed_rules_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformComputedRulesExample
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: An input variable with the name
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: An input variable with the name
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    destroy.go:11:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
+        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
+        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
+        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_computed_rules_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformComputedRulesExample
+--- FAIL: TestTerraformComputedRulesExample (6.03s)
+FAIL
+FAIL	command-line-arguments	6.046s
+FAIL

--- a/test/terraform_computed_rules_test.log
+++ b/test/terraform_computed_rules_test.log
@@ -34,7 +34,7 @@ TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
 TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
 TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66:
 TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: An input variable with the name
 TestTerraformComputedRulesExample 2022-08-24T14:35:04Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -54,7 +54,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -78,7 +78,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -101,7 +101,7 @@ TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
 TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
 TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66:
 TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: An input variable with the name
 TestTerraformComputedRulesExample 2022-08-24T14:35:06Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -121,7 +121,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -148,7 +148,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been

--- a/test/terraform_custom_rules_test.go
+++ b/test/terraform_custom_rules_test.go
@@ -31,6 +31,7 @@ func TestTerraformCustomRulesExample(t *testing.T) {
 	actualComputedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_ingress_rule_ids"))
 	actualComputedManagedIngressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_egress_rule_ids"))
 	actualComputedManagedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_ingress_rule_ids"))
+	actualAutoGroupIngressAllFromSelfRuleKeys := terraform.Output(t, terraformOptions, "auto_group_ingress_all_from_self_rule_keys")
 	actualAutoGroupEgressAllToPublicInternetRuleKeys := terraform.Output(t, terraformOptions, "auto_group_egress_all_to_public_internet_rule_keys")
 
 	expectedIngressRuleKeys := "[ingress-22-22-tcp-from-pl-68a54001 ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24 ingress-450-350-tcp-from-2001:db8::/64 ingress-all-all-all-from-self ingress-all-all-icmp-from-sg-b551fece]"
@@ -41,6 +42,7 @@ func TestTerraformCustomRulesExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 0
 	expectedComputedManagedIngressRuleLength := 0
 	expectedComputedManagedEgressRuleLength := 0
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[]"
 	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[]"
 
 	assert.Equal(t, expectedIngressRuleKeys, actualIngressRuleKeys, "Map %q should match %q", expectedIngressRuleKeys, actualIngressRuleKeys)
@@ -51,5 +53,6 @@ func TestTerraformCustomRulesExample(t *testing.T) {
 	assert.Equal(t, expectedComputedEgressRuleLength, actualComputedEgressRuleLength, "Map %q should match %q", expectedComputedEgressRuleLength, actualComputedEgressRuleLength)
 	assert.Equal(t, expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength, "Map %q should match %q", expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength)
 	assert.Equal(t, expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength, "Map %q should match %q", expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength)
+	assert.Equal(t, expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys, "Map %q should match %q", expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys)
 	assert.Equal(t, expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys, "Map %q should match %q", expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys)
 }

--- a/test/terraform_custom_rules_test.log
+++ b/test/terraform_custom_rules_test.log
@@ -34,7 +34,7 @@ TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
 TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
 TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
 TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: An input variable with the name
 TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -54,7 +54,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -78,7 +78,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -101,7 +101,7 @@ TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
 TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
 TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
 TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: An input variable with the name
 TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -121,7 +121,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -148,7 +148,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been

--- a/test/terraform_custom_rules_test.log
+++ b/test/terraform_custom_rules_test.log
@@ -1,161 +1,688 @@
 === RUN   TestTerraformCustomRulesExample
-TestTerraformCustomRulesExample 2022-08-24T14:34:46Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformCustomRulesExample 2022-08-24T14:34:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:47Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformCustomRulesExample 2022-08-24T14:34:47Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: [0m[32m
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: should now work.
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: An input variable with the name
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: An input variable with the name
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    apply.go:15:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_custom_rules_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformCustomRulesExample
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: An input variable with the name
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: An input variable with the name
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformCustomRulesExample 2022-08-24T14:34:52Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    destroy.go:11:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
-        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
-        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
-        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_custom_rules_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformCustomRulesExample
---- FAIL: TestTerraformCustomRulesExample (5.75s)
-FAIL
-FAIL	command-line-arguments	5.763s
-FAIL
+TestTerraformCustomRulesExample 2022-08-24T15:15:39Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformCustomRulesExample 2022-08-24T15:15:39Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformCustomRulesExample 2022-08-24T15:15:39Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformCustomRulesExample 2022-08-24T15:15:39Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:39Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformCustomRulesExample 2022-08-24T15:15:40Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:40Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformCustomRulesExample 2022-08-24T15:15:40Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: [0m[32m
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: should now work.
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T15:15:41Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T15:15:43Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCustomRulesExample 2022-08-24T15:15:43Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCustomRulesExample 2022-08-24T15:15:43Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + create
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description            = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + name                   = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + tags                   = {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "Name" = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + tags_all               = {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "Example"    = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "Name"       = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + timeouts {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + create = "10m"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + delete = "15m"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "egress-22-22-tcp-to-pl-68a54001"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = 22
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = 22
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = 443
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = 443
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "egress-450-350-tcp-to-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = 350
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = 450
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "egress-all-all-all-to-self"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = true
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-b551fece"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "ingress-22-22-tcp-from-pl-68a54001"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = 22
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = 22
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = 443
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = 443
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "ingress-450-350-tcp-from-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = 350
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = 450
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = true
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be created
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-b551fece"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + from_port                = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + to_port                  = -1
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66: Changes to Outputs:
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + computed_egress_rule_ids                                = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + computed_ingress_rule_ids                               = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + computed_managed_egress_rule_ids                        = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + computed_managed_ingress_rule_ids                       = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + egress_rule_keys                                        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + ingress_rule_keys                                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + managed_egress_rule_keys                                = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:44Z logger.go:66:   + managed_ingress_rule_keys                               = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:45Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-0aa3b28ad13660fc2]
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creating...
+TestTerraformCustomRulesExample 2022-08-24T15:15:48Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creation complete after 1s [id=sgrule-2021342283]
+TestTerraformCustomRulesExample 2022-08-24T15:15:49Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 2s [id=sgrule-3291010153]
+TestTerraformCustomRulesExample 2022-08-24T15:15:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creation complete after 2s [id=sgrule-1879647203]
+TestTerraformCustomRulesExample 2022-08-24T15:15:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creation complete after 3s [id=sgrule-1749409881]
+TestTerraformCustomRulesExample 2022-08-24T15:15:51Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 4s [id=sgrule-1649604954]
+TestTerraformCustomRulesExample 2022-08-24T15:15:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Creation complete after 4s [id=sgrule-3714588632]
+TestTerraformCustomRulesExample 2022-08-24T15:15:53Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creation complete after 5s [id=sgrule-393440574]
+TestTerraformCustomRulesExample 2022-08-24T15:15:53Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 6s [id=sgrule-2420703426]
+TestTerraformCustomRulesExample 2022-08-24T15:15:54Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Creation complete after 6s [id=sgrule-3439538186]
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creation complete after 7s [id=sgrule-2400461950]
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: Outputs:
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: auto_group_ingress_http_from_public_internet_rule_keys = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: computed_egress_rule_ids = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: computed_ingress_rule_ids = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: computed_managed_egress_rule_ids = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: computed_managed_ingress_rule_ids = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: egress_rule_keys = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "egress-22-22-tcp-to-pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "egress-all-all-all-to-self",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "egress-all-all-icmp-to-sg-b551fece",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: ingress_rule_keys = [
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "ingress-22-22-tcp-from-pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "ingress-all-all-all-from-self",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66:   "ingress-all-all-icmp-from-sg-b551fece",
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: ]
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: managed_egress_rule_keys = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: managed_ingress_rule_keys = []
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:55Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:56Z logger.go:66: ["ingress-22-22-tcp-from-pl-68a54001","ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24","ingress-450-350-tcp-from-2001:db8::/64","ingress-all-all-all-from-self","ingress-all-all-icmp-from-sg-b551fece"]
+TestTerraformCustomRulesExample 2022-08-24T15:15:56Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:56Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:57Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:15:57Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:57Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:57Z logger.go:66: ["egress-22-22-tcp-to-pl-68a54001","egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-450-350-tcp-to-2001:db8::/64","egress-all-all-all-to-self","egress-all-all-icmp-to-sg-b551fece"]
+TestTerraformCustomRulesExample 2022-08-24T15:15:57Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:57Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:15:58Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:15:58Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:15:58Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:15:59Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:15:59Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:15:59Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:16:00Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:16:00Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:16:00Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:16:01Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:16:01Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:16:01Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformCustomRulesExample 2022-08-24T15:16:01Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:16:01Z retry.go:91: terraform [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:16:01Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:16:02Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:16:02Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:16:02Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformCustomRulesExample 2022-08-24T15:16:03Z logger.go:66: []
+TestTerraformCustomRulesExample 2022-08-24T15:16:03Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T15:16:03Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T15:16:06Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCustomRulesExample 2022-08-24T15:16:06Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCustomRulesExample 2022-08-24T15:16:06Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-0aa3b28ad13660fc2]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-3439538186]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-3714588632]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1879647203]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-3291010153]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-2420703426]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-2400461950]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-2021342283]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1649604954]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-393440574]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-1749409881]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - destroy
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description            = "ex-custom-rules" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - egress                 = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 443
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 443
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "egress-22-22-tcp-to-pl-68a54001"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 22
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 22
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "egress-450-350-tcp-to-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 350
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 450
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "egress-all-all-all-to-self"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 0
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "-1"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = true
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 0
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-b551fece"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = -1
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "sg-b551fece",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = -1
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                     = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - ingress                = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 443
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 443
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "ingress-22-22-tcp-from-pl-68a54001"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 22
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 22
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "ingress-450-350-tcp-from-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 350
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 450
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "ingress-all-all-all-from-self"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = 0
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "-1"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = true
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = 0
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-b551fece"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - from_port        = -1
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - security_groups  = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                   - "sg-b551fece",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:               - to_port          = -1
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - name                   = "ex-custom-rules" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - tags                   = {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "Name" = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         } -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - tags_all               = {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "Example"    = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "Name"       = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         } -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - timeouts {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - create = "10m" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - delete = "15m" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "egress-22-22-tcp-to-pl-68a54001" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-3439538186" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-1649604954" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "egress-450-350-tcp-to-2001:db8::/64" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 350 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-1879647203" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 450 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-3291010153" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = true -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-b551fece" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                       = "sgrule-1749409881" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id        = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self                     = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type                     = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "ingress-22-22-tcp-from-pl-68a54001" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-3714588632" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-2420703426" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "ingress-450-350-tcp-from-2001:db8::/64" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 350 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-2021342283" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 450 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description       = "ingress-all-all-all-from-self" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                = "sgrule-2400461950" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self              = true -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-b551fece" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - id                       = "sgrule-393440574" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - security_group_id        = "sg-0aa3b28ad13660fc2" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - self                     = false -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66: Changes to Outputs:
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - computed_egress_rule_ids                                = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - computed_ingress_rule_ids                               = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - computed_managed_egress_rule_ids                        = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - egress_rule_keys                                        = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "egress-22-22-tcp-to-pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "egress-450-350-tcp-to-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "egress-all-all-all-to-self",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "egress-all-all-icmp-to-sg-b551fece",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - ingress_rule_keys                                       = [
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "ingress-22-22-tcp-from-pl-68a54001",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "ingress-450-350-tcp-from-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "ingress-all-all-all-from-self",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:       - "ingress-all-all-icmp-from-sg-b551fece",
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:     ] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - managed_egress_rule_keys                                = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:07Z logger.go:66:   - managed_ingress_rule_keys                               = [] -> null
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-2021342283]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destroying... [id=sgrule-2400461950]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1879647203]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-1749409881]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-393440574]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-3439538186]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1649604954]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-3714588632]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-2420703426]
+TestTerraformCustomRulesExample 2022-08-24T15:16:08Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-3291010153]
+TestTerraformCustomRulesExample 2022-08-24T15:16:09Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destruction complete after 0s
+TestTerraformCustomRulesExample 2022-08-24T15:16:10Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destruction complete after 1s
+TestTerraformCustomRulesExample 2022-08-24T15:16:10Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destruction complete after 2s
+TestTerraformCustomRulesExample 2022-08-24T15:16:11Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destruction complete after 2s
+TestTerraformCustomRulesExample 2022-08-24T15:16:12Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destruction complete after 3s
+TestTerraformCustomRulesExample 2022-08-24T15:16:12Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Destruction complete after 4s
+TestTerraformCustomRulesExample 2022-08-24T15:16:13Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 4s
+TestTerraformCustomRulesExample 2022-08-24T15:16:13Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 5s
+TestTerraformCustomRulesExample 2022-08-24T15:16:14Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 6s
+TestTerraformCustomRulesExample 2022-08-24T15:16:15Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Destruction complete after 6s
+TestTerraformCustomRulesExample 2022-08-24T15:16:15Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-0aa3b28ad13660fc2]
+TestTerraformCustomRulesExample 2022-08-24T15:16:16Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformCustomRulesExample 2022-08-24T15:16:16Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T15:16:16Z logger.go:66: Destroy complete! Resources: 11 destroyed.
+--- PASS: TestTerraformCustomRulesExample (36.94s)
+PASS
+ok  	command-line-arguments	36.958s

--- a/test/terraform_custom_rules_test.log
+++ b/test/terraform_custom_rules_test.log
@@ -1,685 +1,161 @@
 === RUN   TestTerraformCustomRulesExample
-TestTerraformCustomRulesExample 2022-08-24T04:32:23Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformCustomRulesExample 2022-08-24T04:32:23Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformCustomRulesExample 2022-08-24T04:32:23Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformCustomRulesExample 2022-08-24T04:32:23Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:23Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformCustomRulesExample 2022-08-24T04:32:24Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:24Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformCustomRulesExample 2022-08-24T04:32:24Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: [0m[32m
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: should now work.
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T04:32:25Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T04:32:28Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCustomRulesExample 2022-08-24T04:32:28Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCustomRulesExample 2022-08-24T04:32:28Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
-TestTerraformCustomRulesExample 2022-08-24T04:32:28Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
-TestTerraformCustomRulesExample 2022-08-24T04:32:28Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + create
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description            = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + name                   = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + tags                   = {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "Name" = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + tags_all               = {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "Example"    = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "Name"       = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + timeouts {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + create = "10m"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + delete = "15m"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "egress-22-22-tcp-to-pl-68a54001"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "egress-450-350-tcp-to-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = 350
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = 450
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "egress-all-all-all-to-self"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = true
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-b551fece"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "ingress-22-22-tcp-from-pl-68a54001"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "ingress-450-350-tcp-from-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = 350
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = 450
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = true
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be created
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-b551fece"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + from_port                = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + to_port                  = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66: Changes to Outputs:
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + auto_group_egress_to_public_internet_rule_ids      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + auto_group_ingress_all_from_self_rule_ids          = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys         = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + computed_egress_rule_ids                           = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + computed_ingress_rule_ids                          = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + computed_managed_egress_rule_ids                   = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + computed_managed_ingress_rule_ids                  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + egress_rule_keys                                   = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + ingress_rule_keys                                  = (known after apply)
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + managed_egress_rule_keys                           = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:29Z logger.go:66:   + managed_ingress_rule_keys                          = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:30Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-0200f6e96537821e3]
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:32Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCustomRulesExample 2022-08-24T04:32:33Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creation complete after 1s [id=sgrule-755832399]
-TestTerraformCustomRulesExample 2022-08-24T04:32:33Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Creation complete after 2s [id=sgrule-631208236]
-TestTerraformCustomRulesExample 2022-08-24T04:32:34Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Creation complete after 2s [id=sgrule-2019231303]
-TestTerraformCustomRulesExample 2022-08-24T04:32:35Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creation complete after 3s [id=sgrule-2991114536]
-TestTerraformCustomRulesExample 2022-08-24T04:32:35Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creation complete after 4s [id=sgrule-4181641746]
-TestTerraformCustomRulesExample 2022-08-24T04:32:36Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Creation complete after 5s [id=sgrule-260900460]
-TestTerraformCustomRulesExample 2022-08-24T04:32:37Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 5s [id=sgrule-197402160]
-TestTerraformCustomRulesExample 2022-08-24T04:32:38Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Creation complete after 6s [id=sgrule-4032395407]
-TestTerraformCustomRulesExample 2022-08-24T04:32:38Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 7s [id=sgrule-2715543894]
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 8s [id=sgrule-2570896889]
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: Outputs:
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: auto_group_egress_to_public_internet_rule_ids = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: auto_group_ingress_all_from_self_rule_ids = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: computed_egress_rule_ids = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: computed_ingress_rule_ids = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: computed_managed_egress_rule_ids = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: computed_managed_ingress_rule_ids = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: egress_rule_keys = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "egress-22-22-tcp-to-pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "egress-all-all-all-to-self",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "egress-all-all-icmp-to-sg-b551fece",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: ingress_rule_keys = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "ingress-22-22-tcp-from-pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "ingress-all-all-all-from-self",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66:   "ingress-all-all-icmp-from-sg-b551fece",
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: managed_egress_rule_keys = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: managed_ingress_rule_keys = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:39Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:40Z logger.go:66: ["ingress-22-22-tcp-from-pl-68a54001","ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24","ingress-450-350-tcp-from-2001:db8::/64","ingress-all-all-all-from-self","ingress-all-all-icmp-from-sg-b551fece"]
-TestTerraformCustomRulesExample 2022-08-24T04:32:40Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:40Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:41Z logger.go:66: []
-TestTerraformCustomRulesExample 2022-08-24T04:32:41Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:41Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:42Z logger.go:66: ["egress-22-22-tcp-to-pl-68a54001","egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-450-350-tcp-to-2001:db8::/64","egress-all-all-all-to-self","egress-all-all-icmp-to-sg-b551fece"]
-TestTerraformCustomRulesExample 2022-08-24T04:32:42Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:42Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:42Z logger.go:66: []
-TestTerraformCustomRulesExample 2022-08-24T04:32:42Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:42Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:43Z logger.go:66: []
-TestTerraformCustomRulesExample 2022-08-24T04:32:43Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:43Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:44Z logger.go:66: []
-TestTerraformCustomRulesExample 2022-08-24T04:32:44Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:44Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:45Z logger.go:66: []
-TestTerraformCustomRulesExample 2022-08-24T04:32:45Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:45Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformCustomRulesExample 2022-08-24T04:32:46Z logger.go:66: []
-TestTerraformCustomRulesExample 2022-08-24T04:32:46Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:46Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformCustomRulesExample 2022-08-24T04:32:47Z logger.go:66: []
-TestTerraformCustomRulesExample 2022-08-24T04:32:47Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T04:32:47Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-24T04:32:49Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCustomRulesExample 2022-08-24T04:32:49Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-0200f6e96537821e3]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-2715543894]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-2570896889]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-631208236]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-2019231303]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-2991114536]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-197402160]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-260900460]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-4181641746]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-755832399]
-TestTerraformCustomRulesExample 2022-08-24T04:32:50Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-4032395407]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - destroy
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description            = "ex-custom-rules" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - egress                 = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "egress-22-22-tcp-to-pl-68a54001"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "egress-450-350-tcp-to-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 350
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 450
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "egress-all-all-all-to-self"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 0
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "-1"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = true
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 0
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-b551fece"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "sg-b551fece",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                     = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - ingress                = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 443
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "ingress-22-22-tcp-from-pl-68a54001"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 22
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "ingress-450-350-tcp-from-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 350
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 450
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "ingress-all-all-all-from-self"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = 0
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "-1"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = true
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = 0
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-b551fece"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - from_port        = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - security_groups  = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                   - "sg-b551fece",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:               - to_port          = -1
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - name                   = "ex-custom-rules" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - tags                   = {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "Name" = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         } -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - tags_all               = {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "Example"    = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "Name"       = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         } -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - timeouts {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - create = "10m" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - delete = "15m" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "egress-22-22-tcp-to-pl-68a54001" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-631208236" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-2715543894" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "egress-450-350-tcp-to-2001:db8::/64" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 350 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-4181641746" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 450 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-197402160" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = true -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-b551fece" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                       = "sgrule-4032395407" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id        = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self                     = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type                     = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "ingress-22-22-tcp-from-pl-68a54001" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-260900460" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-2570896889" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "ingress-450-350-tcp-from-2001:db8::/64" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 350 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-2991114536" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 450 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description       = "ingress-all-all-all-from-self" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                = "sgrule-755832399" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self              = true -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   # module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-b551fece" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - id                       = "sgrule-2019231303" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - security_group_id        = "sg-0200f6e96537821e3" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - self                     = false -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66: Changes to Outputs:
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - auto_group_egress_to_public_internet_rule_ids      = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - auto_group_ingress_all_from_self_rule_ids          = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys         = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - computed_egress_rule_ids                           = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - computed_ingress_rule_ids                          = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - computed_managed_egress_rule_ids                   = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - computed_managed_ingress_rule_ids                  = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - egress_rule_keys                                   = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "egress-22-22-tcp-to-pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "egress-450-350-tcp-to-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "egress-all-all-all-to-self",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "egress-all-all-icmp-to-sg-b551fece",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - ingress_rule_keys                                  = [
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "ingress-22-22-tcp-from-pl-68a54001",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "ingress-450-350-tcp-from-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "ingress-all-all-all-from-self",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:       - "ingress-all-all-icmp-from-sg-b551fece",
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:     ] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - managed_egress_rule_keys                           = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:51Z logger.go:66:   - managed_ingress_rule_keys                          = [] -> null
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-2715543894]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-4032395407]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-4181641746]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-2991114536]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-260900460]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-631208236]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-2570896889]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-197402160]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destroying... [id=sgrule-755832399]
-TestTerraformCustomRulesExample 2022-08-24T04:32:52Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-2019231303]
-TestTerraformCustomRulesExample 2022-08-24T04:32:53Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destruction complete after 1s
-TestTerraformCustomRulesExample 2022-08-24T04:32:53Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 2s
-TestTerraformCustomRulesExample 2022-08-24T04:32:54Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-b551fece"]: Destruction complete after 2s
-TestTerraformCustomRulesExample 2022-08-24T04:32:55Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 3s
-TestTerraformCustomRulesExample 2022-08-24T04:32:55Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destruction complete after 4s
-TestTerraformCustomRulesExample 2022-08-24T04:32:56Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-68a54001"]: Destruction complete after 4s
-TestTerraformCustomRulesExample 2022-08-24T04:32:56Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 5s
-TestTerraformCustomRulesExample 2022-08-24T04:32:57Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destruction complete after 6s
-TestTerraformCustomRulesExample 2022-08-24T04:32:58Z logger.go:66: module.security_group.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-b551fece"]: Destruction complete after 6s
-TestTerraformCustomRulesExample 2022-08-24T04:32:58Z logger.go:66: module.security_group.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-68a54001"]: Destruction complete after 7s
-TestTerraformCustomRulesExample 2022-08-24T04:32:59Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-0200f6e96537821e3]
-TestTerraformCustomRulesExample 2022-08-24T04:33:00Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformCustomRulesExample 2022-08-24T04:33:00Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-24T04:33:00Z logger.go:66: Destroy complete! Resources: 11 destroyed.
---- PASS: TestTerraformCustomRulesExample (36.72s)
-PASS
-ok  	command-line-arguments	36.733s
+TestTerraformCustomRulesExample 2022-08-24T14:34:46Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:46Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformCustomRulesExample 2022-08-24T14:34:47Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:47Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformCustomRulesExample 2022-08-24T14:34:47Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: [0m[32m
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: should now work.
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T14:34:48Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: An input variable with the name
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: An input variable with the name
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    apply.go:15:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_custom_rules_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformCustomRulesExample
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T14:34:50Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: An input variable with the name
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: An input variable with the name
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformCustomRulesExample 2022-08-24T14:34:52Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    destroy.go:11:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
+        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
+        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
+        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_custom_rules_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformCustomRulesExample
+--- FAIL: TestTerraformCustomRulesExample (5.75s)
+FAIL
+FAIL	command-line-arguments	5.763s
+FAIL

--- a/test/terraform_managed_rules_test.go
+++ b/test/terraform_managed_rules_test.go
@@ -31,6 +31,7 @@ func TestTerraformManagedRulesExample(t *testing.T) {
 	actualComputedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_ingress_rule_ids"))
 	actualComputedManagedIngressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_egress_rule_ids"))
 	actualComputedManagedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_ingress_rule_ids"))
+	actualAutoGroupIngressAllFromSelfRuleKeys := terraform.Output(t, terraformOptions, "auto_group_ingress_all_from_self_rule_keys")
 	actualAutoGroupEgressAllToPublicInternetRuleKeys := terraform.Output(t, terraformOptions, "auto_group_egress_all_to_public_internet_rule_keys")
 
 	expectedIngressRuleKeys := "[]"
@@ -41,6 +42,7 @@ func TestTerraformManagedRulesExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 0
 	expectedComputedManagedIngressRuleLength := 0
 	expectedComputedManagedEgressRuleLength := 0
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[]"
 	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[]"
 
 	assert.Equal(t, expectedIngressRuleKeys, actualIngressRuleKeys, "Map %q should match %q", expectedIngressRuleKeys, actualIngressRuleKeys)
@@ -51,5 +53,6 @@ func TestTerraformManagedRulesExample(t *testing.T) {
 	assert.Equal(t, expectedComputedEgressRuleLength, actualComputedEgressRuleLength, "Map %q should match %q", expectedComputedEgressRuleLength, actualComputedEgressRuleLength)
 	assert.Equal(t, expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength, "Map %q should match %q", expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength)
 	assert.Equal(t, expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength, "Map %q should match %q", expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength)
+	assert.Equal(t, expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys, "Map %q should match %q", expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys)
 	assert.Equal(t, expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys, "Map %q should match %q", expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys)
 }

--- a/test/terraform_managed_rules_test.log
+++ b/test/terraform_managed_rules_test.log
@@ -1,685 +1,161 @@
 === RUN   TestTerraformManagedRulesExample
-TestTerraformManagedRulesExample 2022-08-24T04:33:01Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformManagedRulesExample 2022-08-24T04:33:01Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformManagedRulesExample 2022-08-24T04:33:01Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformManagedRulesExample 2022-08-24T04:33:01Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:01Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformManagedRulesExample 2022-08-24T04:33:02Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:02Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformManagedRulesExample 2022-08-24T04:33:02Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: [0m[32m
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: should now work.
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T04:33:03Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + create
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: Terraform will perform the following actions:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description            = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                     = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + name                   = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + tags                   = {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "Name" = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + tags_all               = {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "Example"    = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "Name"       = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + timeouts {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + create = "10m"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + delete = "15m"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "egress-all-all-to-self"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = true
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "egress-all-icmp-to-sg-b551fece"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + cidr_blocks              = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = 443
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = 443
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-68a54001"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + cidr_blocks              = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "ingress-all-all-from-self"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = true
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "ingress-all-icmp-from-sg-b551fece"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be created
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-68a54001"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + from_port                = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:           + "pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + to_port                  = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66: Changes to Outputs:
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + auto_group_egress_to_public_internet_rule_ids      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + auto_group_ingress_all_from_self_rule_ids          = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys         = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + computed_egress_rule_ids                           = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + computed_ingress_rule_ids                          = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + computed_managed_egress_rule_ids                   = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + computed_managed_ingress_rule_ids                  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + egress_rule_keys                                   = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + ingress_rule_keys                                  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + managed_egress_rule_keys                           = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:06Z logger.go:66:   + managed_ingress_rule_keys                          = (known after apply)
-TestTerraformManagedRulesExample 2022-08-24T04:33:07Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-03e3202fc2c946f8e]
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:09Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creating...
-TestTerraformManagedRulesExample 2022-08-24T04:33:10Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Creation complete after 1s [id=sgrule-554317924]
-TestTerraformManagedRulesExample 2022-08-24T04:33:11Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 2s [id=sgrule-18779350]
-TestTerraformManagedRulesExample 2022-08-24T04:33:12Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 2s [id=sgrule-2478908175]
-TestTerraformManagedRulesExample 2022-08-24T04:33:13Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creation complete after 3s [id=sgrule-1016651147]
-TestTerraformManagedRulesExample 2022-08-24T04:33:13Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 4s [id=sgrule-2000901815]
-TestTerraformManagedRulesExample 2022-08-24T04:33:14Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 5s [id=sgrule-1218112426]
-TestTerraformManagedRulesExample 2022-08-24T04:33:15Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creation complete after 6s [id=sgrule-1027918888]
-TestTerraformManagedRulesExample 2022-08-24T04:33:16Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creation complete after 6s [id=sgrule-1372268140]
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Creation complete after 7s [id=sgrule-1330802423]
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creation complete after 8s [id=sgrule-876207616]
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: Outputs:
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: auto_group_egress_to_public_internet_rule_ids = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: auto_group_ingress_all_from_self_rule_ids = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: computed_egress_rule_ids = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: computed_ingress_rule_ids = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: computed_managed_egress_rule_ids = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: computed_managed_ingress_rule_ids = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: egress_rule_keys = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: ingress_rule_keys = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: managed_egress_rule_keys = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "egress-all-all-to-self",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "egress-all-icmp-to-sg-b551fece",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "egress-ssh-tcp-to-pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: managed_ingress_rule_keys = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "ingress-all-all-from-self",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "ingress-all-icmp-from-sg-b551fece",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66:   "ingress-ssh-tcp-from-pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:17Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:18Z logger.go:66: []
-TestTerraformManagedRulesExample 2022-08-24T04:33:18Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:18Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:19Z logger.go:66: ["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-all-all-from-self","ingress-all-icmp-from-sg-b551fece","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-68a54001"]
-TestTerraformManagedRulesExample 2022-08-24T04:33:19Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:19Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:20Z logger.go:66: []
-TestTerraformManagedRulesExample 2022-08-24T04:33:20Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:20Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:21Z logger.go:66: ["egress-all-all-to-self","egress-all-icmp-to-sg-b551fece","egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-68a54001"]
-TestTerraformManagedRulesExample 2022-08-24T04:33:21Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:21Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:22Z logger.go:66: []
-TestTerraformManagedRulesExample 2022-08-24T04:33:22Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:22Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:22Z logger.go:66: []
-TestTerraformManagedRulesExample 2022-08-24T04:33:22Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:22Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:23Z logger.go:66: []
-TestTerraformManagedRulesExample 2022-08-24T04:33:23Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:23Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformManagedRulesExample 2022-08-24T04:33:24Z logger.go:66: []
-TestTerraformManagedRulesExample 2022-08-24T04:33:24Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:24Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformManagedRulesExample 2022-08-24T04:33:25Z logger.go:66: []
-TestTerraformManagedRulesExample 2022-08-24T04:33:25Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T04:33:25Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T04:33:28Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformManagedRulesExample 2022-08-24T04:33:28Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformManagedRulesExample 2022-08-24T04:33:28Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-03e3202fc2c946f8e]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1016651147]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-876207616]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-2478908175]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-1330802423]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-1027918888]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-2000901815]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-18779350]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1218112426]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-554317924]
-TestTerraformManagedRulesExample 2022-08-24T04:33:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1372268140]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - destroy
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66: Terraform will perform the following actions:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description            = "ex-managed-rules" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - egress                 = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 443
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 443
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "egress-all-all-to-self"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "-1"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = true
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "egress-all-icmp-to-sg-b551fece"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "icmp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "sg-b551fece",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-68a54001"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                     = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - ingress                = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "-1"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "ingress-all-all-from-self"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "-1"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = true
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "ingress-all-icmp-from-sg-b551fece"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "icmp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "sg-b551fece",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = -1
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 5432
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-68a54001"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - from_port        = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                   - "pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:               - to_port          = 22
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - name                   = "ex-managed-rules" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - tags                   = {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "Name" = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         } -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - tags_all               = {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "Example"    = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "Name"       = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         } -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - timeouts {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - create = "10m" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - delete = "15m" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "egress-all-all-to-self" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-1372268140" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = true -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description              = "egress-all-icmp-to-sg-b551fece" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                       = "sgrule-554317924" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id        = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self                     = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type                     = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - cidr_blocks       = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-2478908175" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-1218112426" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-68a54001" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-876207616" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - cidr_blocks       = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-18779350" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "ingress-all-all-from-self" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-1016651147" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = true -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description              = "ingress-all-icmp-from-sg-b551fece" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port                = -1 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                       = "sgrule-1330802423" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id        = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self                     = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port                  = -1 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-2000901815" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-68a54001" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - id                = "sgrule-1027918888" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:           - "pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - security_group_id = "sg-03e3202fc2c946f8e" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66: Changes to Outputs:
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - auto_group_egress_to_public_internet_rule_ids      = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - auto_group_ingress_all_from_self_rule_ids          = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys         = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - computed_egress_rule_ids                           = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - computed_ingress_rule_ids                          = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - computed_managed_egress_rule_ids                   = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - computed_managed_ingress_rule_ids                  = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - egress_rule_keys                                   = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - ingress_rule_keys                                  = [] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - managed_egress_rule_keys                           = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "egress-all-all-to-self",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "egress-all-icmp-to-sg-b551fece",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "egress-ssh-tcp-to-pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:   - managed_ingress_rule_keys                          = [
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "ingress-all-all-from-self",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "ingress-all-icmp-from-sg-b551fece",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:       - "ingress-ssh-tcp-from-pl-68a54001",
-TestTerraformManagedRulesExample 2022-08-24T04:33:30Z logger.go:66:     ] -> null
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-554317924]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-18779350]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-2478908175]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-2000901815]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1218112426]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-1027918888]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destroying... [id=sgrule-1372268140]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destroying... [id=sgrule-1016651147]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-1330802423]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-876207616]
-TestTerraformManagedRulesExample 2022-08-24T04:33:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 1s
-TestTerraformManagedRulesExample 2022-08-24T04:33:32Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Destruction complete after 1s
-TestTerraformManagedRulesExample 2022-08-24T04:33:33Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 2s
-TestTerraformManagedRulesExample 2022-08-24T04:33:33Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 3s
-TestTerraformManagedRulesExample 2022-08-24T04:33:34Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destruction complete after 3s
-TestTerraformManagedRulesExample 2022-08-24T04:33:34Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Destruction complete after 4s
-TestTerraformManagedRulesExample 2022-08-24T04:33:35Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destruction complete after 5s
-TestTerraformManagedRulesExample 2022-08-24T04:33:36Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destruction complete after 5s
-TestTerraformManagedRulesExample 2022-08-24T04:33:36Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 6s
-TestTerraformManagedRulesExample 2022-08-24T04:33:37Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destruction complete after 6s
-TestTerraformManagedRulesExample 2022-08-24T04:33:37Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-03e3202fc2c946f8e]
-TestTerraformManagedRulesExample 2022-08-24T04:33:38Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 0s
-TestTerraformManagedRulesExample 2022-08-24T04:33:38Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T04:33:38Z logger.go:66: Destroy complete! Resources: 11 destroyed.
---- PASS: TestTerraformManagedRulesExample (37.11s)
-PASS
-ok  	command-line-arguments	37.125s
+TestTerraformManagedRulesExample 2022-08-24T14:34:53Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformManagedRulesExample 2022-08-24T14:34:54Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:54Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformManagedRulesExample 2022-08-24T14:34:54Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: [0m[32m
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: should now work.
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: An input variable with the name
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: An input variable with the name
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    apply.go:15:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_managed_rules_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformManagedRulesExample
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: An input variable with the name
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: An input variable with the name
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    destroy.go:11:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
+        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
+        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
+        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_managed_rules_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformManagedRulesExample
+--- FAIL: TestTerraformManagedRulesExample (5.88s)
+FAIL
+FAIL	command-line-arguments	5.896s
+FAIL

--- a/test/terraform_managed_rules_test.log
+++ b/test/terraform_managed_rules_test.log
@@ -1,161 +1,688 @@
 === RUN   TestTerraformManagedRulesExample
-TestTerraformManagedRulesExample 2022-08-24T14:34:53Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:53Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformManagedRulesExample 2022-08-24T14:34:54Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:54Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformManagedRulesExample 2022-08-24T14:34:54Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: [0m[32m
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: should now work.
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T14:34:55Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: An input variable with the name
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: An input variable with the name
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    apply.go:15:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_managed_rules_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformManagedRulesExample
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: An input variable with the name
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: An input variable with the name
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    destroy.go:11:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
-        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
-        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
-        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_managed_rules_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformManagedRulesExample
---- FAIL: TestTerraformManagedRulesExample (5.88s)
-FAIL
-FAIL	command-line-arguments	5.896s
-FAIL
+TestTerraformManagedRulesExample 2022-08-24T15:16:17Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformManagedRulesExample 2022-08-24T15:16:17Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformManagedRulesExample 2022-08-24T15:16:17Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformManagedRulesExample 2022-08-24T15:16:17Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:17Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformManagedRulesExample 2022-08-24T15:16:18Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:18Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformManagedRulesExample 2022-08-24T15:16:18Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: [0m[32m
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: should now work.
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T15:16:19Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T15:16:21Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformManagedRulesExample 2022-08-24T15:16:21Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + create
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: Terraform will perform the following actions:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description            = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                     = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + name                   = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + tags                   = {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "Name" = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + tags_all               = {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "Example"    = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "Name"       = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + timeouts {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + create = "10m"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + delete = "15m"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "egress-all-all-to-self"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = true
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "egress-all-icmp-to-sg-b551fece"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + cidr_blocks              = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = 443
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = 443
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-68a54001"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + cidr_blocks              = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "ingress-all-all-from-self"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = true
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "ingress-all-icmp-from-sg-b551fece"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be created
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-68a54001"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + from_port                = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:           + "pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + to_port                  = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66: Changes to Outputs:
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + computed_egress_rule_ids                                = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + computed_ingress_rule_ids                               = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + computed_managed_egress_rule_ids                        = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + computed_managed_ingress_rule_ids                       = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + egress_rule_keys                                        = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + ingress_rule_keys                                       = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + managed_egress_rule_keys                                = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:22Z logger.go:66:   + managed_ingress_rule_keys                               = (known after apply)
+TestTerraformManagedRulesExample 2022-08-24T15:16:23Z logger.go:66: module.security_group.aws_security_group.self[0]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group.self[0]: Creation complete after 2s [id=sg-052c34fae0a055cdc]
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:25Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creating...
+TestTerraformManagedRulesExample 2022-08-24T15:16:26Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Creation complete after 1s [id=sgrule-279213232]
+TestTerraformManagedRulesExample 2022-08-24T15:16:27Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 1s [id=sgrule-3916951639]
+TestTerraformManagedRulesExample 2022-08-24T15:16:28Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 2s [id=sgrule-3197483677]
+TestTerraformManagedRulesExample 2022-08-24T15:16:28Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creation complete after 3s [id=sgrule-202988680]
+TestTerraformManagedRulesExample 2022-08-24T15:16:29Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 3s [id=sgrule-413771949]
+TestTerraformManagedRulesExample 2022-08-24T15:16:30Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Creation complete after 4s [id=sgrule-4029669394]
+TestTerraformManagedRulesExample 2022-08-24T15:16:31Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Creation complete after 5s [id=sgrule-4127318542]
+TestTerraformManagedRulesExample 2022-08-24T15:16:32Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creation complete after 6s [id=sgrule-1328768107]
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 7s [id=sgrule-2710198792]
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Creation complete after 8s [id=sgrule-2363870039]
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: Outputs:
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: auto_group_ingress_http_from_public_internet_rule_keys = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: computed_egress_rule_ids = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: computed_ingress_rule_ids = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: computed_managed_egress_rule_ids = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: computed_managed_ingress_rule_ids = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: egress_rule_keys = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: ingress_rule_keys = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: managed_egress_rule_keys = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "egress-all-all-to-self",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "egress-all-icmp-to-sg-b551fece",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "egress-ssh-tcp-to-pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: managed_ingress_rule_keys = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "ingress-all-all-from-self",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "ingress-all-icmp-from-sg-b551fece",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66:   "ingress-ssh-tcp-from-pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:33Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:34Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:34Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:34Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:35Z logger.go:66: ["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-all-all-from-self","ingress-all-icmp-from-sg-b551fece","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-68a54001"]
+TestTerraformManagedRulesExample 2022-08-24T15:16:35Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:35Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:36Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:36Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:36Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:37Z logger.go:66: ["egress-all-all-to-self","egress-all-icmp-to-sg-b551fece","egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-68a54001"]
+TestTerraformManagedRulesExample 2022-08-24T15:16:37Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:37Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:37Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:37Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:37Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:38Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:38Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:38Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:39Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:39Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:39Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformManagedRulesExample 2022-08-24T15:16:40Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:40Z retry.go:91: terraform [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:40Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:41Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:41Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:41Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformManagedRulesExample 2022-08-24T15:16:42Z logger.go:66: []
+TestTerraformManagedRulesExample 2022-08-24T15:16:42Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T15:16:42Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-68a54001]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-9ce7cafb]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group.self[0]: Refreshing state... [id=sg-052c34fae0a055cdc]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-202988680]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-413771949]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Refreshing state... [id=sgrule-2363870039]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Refreshing state... [id=sgrule-4029669394]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-2710198792]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-3197483677]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Refreshing state... [id=sgrule-279213232]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Refreshing state... [id=sgrule-4127318542]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1328768107]
+TestTerraformManagedRulesExample 2022-08-24T15:16:45Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-3916951639]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - destroy
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66: Terraform will perform the following actions:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group.self[0] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description            = "ex-managed-rules" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - egress                 = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 443
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 443
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "egress-all-all-to-self"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "-1"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = true
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "egress-all-icmp-to-sg-b551fece"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "icmp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "sg-b551fece",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-68a54001"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                     = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - ingress                = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "-1"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "ingress-all-all-from-self"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "-1"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = true
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "ingress-all-icmp-from-sg-b551fece"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "icmp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "sg-b551fece",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = -1
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 5432
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-68a54001"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - from_port        = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                   - "pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:               - to_port          = 22
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - name                   = "ex-managed-rules" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - tags                   = {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "Name" = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         } -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - tags_all               = {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "Example"    = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "Name"       = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         } -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - timeouts {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - create = "10m" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - delete = "15m" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "egress-all-all-to-self" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-1328768107" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = true -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description              = "egress-all-icmp-to-sg-b551fece" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                       = "sgrule-2363870039" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id        = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self                     = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type                     = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - cidr_blocks       = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-3197483677" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-413771949" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-68a54001" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-279213232" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - cidr_blocks       = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-2710198792" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "ingress-all-all-from-self" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-202988680" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = true -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description              = "ingress-all-icmp-from-sg-b551fece" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port                = -1 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                       = "sgrule-4029669394" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id        = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self                     = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port                  = -1 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-3916951639" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-68a54001" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - id                = "sgrule-4127318542" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:           - "pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - security_group_id = "sg-052c34fae0a055cdc" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66: Changes to Outputs:
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - computed_egress_rule_ids                                = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - computed_ingress_rule_ids                               = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - computed_managed_egress_rule_ids                        = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - egress_rule_keys                                        = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - ingress_rule_keys                                       = [] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - managed_egress_rule_keys                                = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "egress-all-all-to-self",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "egress-all-icmp-to-sg-b551fece",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "egress-ssh-tcp-to-pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:   - managed_ingress_rule_keys                               = [
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "ingress-all-all-from-self",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "ingress-all-icmp-from-sg-b551fece",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:       - "ingress-ssh-tcp-from-pl-68a54001",
+TestTerraformManagedRulesExample 2022-08-24T15:16:46Z logger.go:66:     ] -> null
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-3197483677]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-413771949]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Destroying... [id=sgrule-4029669394]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destroying... [id=sgrule-279213232]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-2710198792]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Destroying... [id=sgrule-2363870039]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destroying... [id=sgrule-4127318542]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destroying... [id=sgrule-1328768107]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-3916951639]
+TestTerraformManagedRulesExample 2022-08-24T15:16:47Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destroying... [id=sgrule-202988680]
+TestTerraformManagedRulesExample 2022-08-24T15:16:48Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 0s
+TestTerraformManagedRulesExample 2022-08-24T15:16:48Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 1s
+TestTerraformManagedRulesExample 2022-08-24T15:16:49Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-b551fece"]: Destruction complete after 2s
+TestTerraformManagedRulesExample 2022-08-24T15:16:50Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 2s
+TestTerraformManagedRulesExample 2022-08-24T15:16:50Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-68a54001"]: Destruction complete after 3s
+TestTerraformManagedRulesExample 2022-08-24T15:16:51Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-b551fece"]: Destruction complete after 4s
+TestTerraformManagedRulesExample 2022-08-24T15:16:52Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-68a54001"]: Destruction complete after 4s
+TestTerraformManagedRulesExample 2022-08-24T15:16:52Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 5s
+TestTerraformManagedRulesExample 2022-08-24T15:16:53Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destruction complete after 5s
+TestTerraformManagedRulesExample 2022-08-24T15:16:53Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destruction complete after 6s
+TestTerraformManagedRulesExample 2022-08-24T15:16:53Z logger.go:66: module.security_group.aws_security_group.self[0]: Destroying... [id=sg-052c34fae0a055cdc]
+TestTerraformManagedRulesExample 2022-08-24T15:16:54Z logger.go:66: module.security_group.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformManagedRulesExample 2022-08-24T15:16:54Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-24T15:16:54Z logger.go:66: Destroy complete! Resources: 11 destroyed.
+--- PASS: TestTerraformManagedRulesExample (37.68s)
+PASS
+ok  	command-line-arguments	37.698s

--- a/test/terraform_managed_rules_test.log
+++ b/test/terraform_managed_rules_test.log
@@ -34,7 +34,7 @@ TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
 TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
 TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66:
 TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: An input variable with the name
 TestTerraformManagedRulesExample 2022-08-24T14:34:57Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -54,7 +54,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -78,7 +78,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -101,7 +101,7 @@ TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
 TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
 TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66:
 TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: An input variable with the name
 TestTerraformManagedRulesExample 2022-08-24T14:34:59Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -121,7 +121,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -148,7 +148,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been

--- a/test/terraform_rules_only_test.go
+++ b/test/terraform_rules_only_test.go
@@ -31,6 +31,7 @@ func TestTerraformRulesOnlyExample(t *testing.T) {
 	actualComputedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_ingress_rule_ids"))
 	actualComputedManagedIngressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_egress_rule_ids"))
 	actualComputedManagedEgressRuleLength := len(terraform.OutputList(t, terraformOptions, "computed_managed_ingress_rule_ids"))
+	actualAutoGroupIngressAllFromSelfRuleKeys := terraform.Output(t, terraformOptions, "auto_group_ingress_all_from_self_rule_keys")
 	actualAutoGroupEgressAllToPublicInternetRuleKeys := terraform.Output(t, terraformOptions, "auto_group_egress_all_to_public_internet_rule_keys")
 
 	expectedIngressRuleKeys := "[]"
@@ -41,6 +42,7 @@ func TestTerraformRulesOnlyExample(t *testing.T) {
 	expectedComputedEgressRuleLength := 0
 	expectedComputedManagedIngressRuleLength := 0
 	expectedComputedManagedEgressRuleLength := 0
+	expectedAutoGroupIngressAllFromSelfRuleKeys := "[]"
 	expectedAutoGroupEgressAllToPublicInternetRuleKeys := "[]"
 
 	assert.Equal(t, expectedIngressRuleKeys, actualIngressRuleKeys, "Map %q should match %q", expectedIngressRuleKeys, actualIngressRuleKeys)
@@ -51,5 +53,6 @@ func TestTerraformRulesOnlyExample(t *testing.T) {
 	assert.Equal(t, expectedComputedEgressRuleLength, actualComputedEgressRuleLength, "Map %q should match %q", expectedComputedEgressRuleLength, actualComputedEgressRuleLength)
 	assert.Equal(t, expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength, "Map %q should match %q", expectedComputedManagedIngressRuleLength, actualComputedManagedIngressRuleLength)
 	assert.Equal(t, expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength, "Map %q should match %q", expectedComputedManagedEgressRuleLength, actualComputedManagedEgressRuleLength)
+	assert.Equal(t, expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys, "Map %q should match %q", expectedAutoGroupIngressAllFromSelfRuleKeys, actualAutoGroupIngressAllFromSelfRuleKeys)
 	assert.Equal(t, expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys, "Map %q should match %q", expectedAutoGroupEgressAllToPublicInternetRuleKeys, actualAutoGroupEgressAllToPublicInternetRuleKeys)
 }

--- a/test/terraform_rules_only_test.log
+++ b/test/terraform_rules_only_test.log
@@ -1,161 +1,230 @@
 === RUN   TestTerraformRulesOnlyExample
-TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformRulesOnlyExample 2022-08-24T14:35:09Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:09Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformRulesOnlyExample 2022-08-24T14:35:09Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: [0m[32m
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: should now work.
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: An input variable with the name
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: An input variable with the name
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    apply.go:15:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_rules_only_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformRulesOnlyExample
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: An input variable with the name
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: Error: Reference to undeclared input variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: An input variable with the name
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: declared. This variable can be declared with a variable
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_https_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-Error: Reference to undeclared input variable
-
-  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-An input variable with the name
-"create_auto_group_ingress_http_from_public_internet_rules" has not been
-declared. This variable can be declared with a variable
-"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-    destroy.go:11:
-        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
-        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
-        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
-        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
-        	            				/workspaces/terraform-aws-security-group/test/terraform_rules_only_test.go:23
-        	Error:      	Received unexpected error:
-        	            	FatalError{Underlying: error while running command: exit status 1;
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
-        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
-
-        	            	Error: Reference to undeclared input variable
-
-        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
-
-        	            	An input variable with the name
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
-        	            	declared. This variable can be declared with a variable
-        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
-        	Test:       	TestTerraformRulesOnlyExample
---- FAIL: TestTerraformRulesOnlyExample (5.81s)
-FAIL
-FAIL	command-line-arguments	5.835s
-FAIL
+TestTerraformRulesOnlyExample 2022-08-24T15:17:32Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:32Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:32Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformRulesOnlyExample 2022-08-24T15:17:32Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:32Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformRulesOnlyExample 2022-08-24T15:17:33Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:33Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformRulesOnlyExample 2022-08-24T15:17:33Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: [0m[32m
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: should now work.
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:34Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:36Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + create
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: Terraform will perform the following actions:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   # aws_security_group.pre_existing_sg will be created
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + resource "aws_security_group" "pre_existing_sg" {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + description            = "ex-rules-only-pre-existing-sg"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + id                     = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + name                   = "ex-rules-only-pre-existing-sg"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + tags                   = {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:           + "Name" = "ex-rules-only-pre-existing-sg"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:         }
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + tags_all               = {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:           + "Example"    = "ex-rules-only"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:           + "Name"       = "ex-rules-only-pre-existing-sg"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:         }
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"] will be created
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + description              = "ingress-http-80-tcp-from-sg-b551fece"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + from_port                = 80
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + id                       = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + self                     = false
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + source_security_group_id = "sg-b551fece"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + to_port                  = 80
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:       + type                     = "ingress"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: Plan: 2 to add, 0 to change, 0 to destroy.
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66: Changes to Outputs:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys      = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys              = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + auto_group_ingress_http_from_public_internet_rule_keys  = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + computed_egress_rule_ids                                = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + computed_ingress_rule_ids                               = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + computed_managed_egress_rule_ids                        = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + computed_managed_ingress_rule_ids                       = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + egress_rule_keys                                        = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + ingress_rule_keys                                       = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + managed_egress_rule_keys                                = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + managed_ingress_rule_keys                               = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:37Z logger.go:66:   + pre_existing_sg_id                                      = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-24T15:17:38Z logger.go:66: aws_security_group.pre_existing_sg: Creating...
+TestTerraformRulesOnlyExample 2022-08-24T15:17:40Z logger.go:66: aws_security_group.pre_existing_sg: Creation complete after 2s [id=sg-0fe32e35938e3bdf5]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:40Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Creating...
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Creation complete after 1s [id=sgrule-1451296666]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: Outputs:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: auto_group_ingress_http_from_public_internet_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: auto_group_ingress_https_from_public_internet_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: computed_egress_rule_ids = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: computed_ingress_rule_ids = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: computed_managed_egress_rule_ids = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: computed_managed_ingress_rule_ids = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: egress_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: ingress_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: managed_egress_rule_keys = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: managed_ingress_rule_keys = [
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66:   "ingress-http-80-tcp-from-sg-b551fece",
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: ]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: pre_existing_sg_id = "sg-0fe32e35938e3bdf5"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:41Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:42Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:42Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:42Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:43Z logger.go:66: ["ingress-http-80-tcp-from-sg-b551fece"]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:43Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:43Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:44Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:44Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:44Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:45Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:45Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:45Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:46Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:46Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:46Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:46Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:46Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:46Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:47Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:47Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:47Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:48Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:48Z retry.go:91: terraform [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:48Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_ingress_all_from_self_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:49Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:49Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:49Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:50Z logger.go:66: []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:50Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:50Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:52Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-24T15:17:53Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:53Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-24T15:17:53Z logger.go:66: aws_security_group.pre_existing_sg: Refreshing state... [id=sg-0fe32e35938e3bdf5]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:53Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-b551fece]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:53Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Refreshing state... [id=sgrule-1451296666]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - destroy
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66: Terraform will perform the following actions:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   # aws_security_group.pre_existing_sg will be destroyed
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - resource "aws_security_group" "pre_existing_sg" {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-0fe32e35938e3bdf5" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - description            = "ex-rules-only-pre-existing-sg" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - egress                 = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - id                     = "sg-0fe32e35938e3bdf5" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - ingress                = [
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:           - {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - cidr_blocks      = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - description      = "ingress-http-80-tcp-from-sg-b551fece"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - from_port        = 80
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - protocol         = "tcp"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - security_groups  = [
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:                   - "sg-b551fece",
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:                 ]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - self             = false
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:               - to_port          = 80
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:             },
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:         ] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - name                   = "ex-rules-only-pre-existing-sg" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - owner_id               = "326504147071" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - tags                   = {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:           - "Name" = "ex-rules-only-pre-existing-sg"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:         } -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - tags_all               = {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:           - "Example"    = "ex-rules-only"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:           - "Name"       = "ex-rules-only-pre-existing-sg"
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:         } -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"] will be destroyed
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - description              = "ingress-http-80-tcp-from-sg-b551fece" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - from_port                = 80 -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - id                       = "sgrule-1451296666" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - security_group_id        = "sg-0fe32e35938e3bdf5" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - self                     = false -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - to_port                  = 80 -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66: Plan: 0 to add, 0 to change, 2 to destroy.
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66: Changes to Outputs:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys      = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys              = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - auto_group_ingress_http_from_public_internet_rule_keys  = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - auto_group_ingress_https_from_public_internet_rule_keys = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - computed_egress_rule_ids                                = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - computed_ingress_rule_ids                               = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - computed_managed_egress_rule_ids                        = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - computed_managed_ingress_rule_ids                       = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - egress_rule_keys                                        = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - ingress_rule_keys                                       = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - managed_egress_rule_keys                                = [] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - managed_ingress_rule_keys                               = [
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:       - "ingress-http-80-tcp-from-sg-b551fece",
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:     ] -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:54Z logger.go:66:   - pre_existing_sg_id                                      = "sg-0fe32e35938e3bdf5" -> null
+TestTerraformRulesOnlyExample 2022-08-24T15:17:55Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Destroying... [id=sgrule-1451296666]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:55Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Destruction complete after 1s
+TestTerraformRulesOnlyExample 2022-08-24T15:17:55Z logger.go:66: aws_security_group.pre_existing_sg: Destroying... [id=sg-0fe32e35938e3bdf5]
+TestTerraformRulesOnlyExample 2022-08-24T15:17:56Z logger.go:66: aws_security_group.pre_existing_sg: Destruction complete after 1s
+TestTerraformRulesOnlyExample 2022-08-24T15:17:56Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T15:17:56Z logger.go:66: Destroy complete! Resources: 2 destroyed.
+--- PASS: TestTerraformRulesOnlyExample (24.34s)
+PASS
+ok  	command-line-arguments	24.358s

--- a/test/terraform_rules_only_test.log
+++ b/test/terraform_rules_only_test.log
@@ -1,227 +1,161 @@
 === RUN   TestTerraformRulesOnlyExample
-TestTerraformRulesOnlyExample 2022-08-24T04:34:13Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:13Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:14Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformRulesOnlyExample 2022-08-24T04:34:14Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:14Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformRulesOnlyExample 2022-08-24T04:34:14Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:14Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformRulesOnlyExample 2022-08-24T04:34:14Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: [0m[32m
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: should now work.
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:15Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:18Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + create
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: Terraform will perform the following actions:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   # aws_security_group.pre_existing_sg will be created
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + resource "aws_security_group" "pre_existing_sg" {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + description            = "ex-rules-only-pre-existing-sg"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + id                     = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + name                   = "ex-rules-only-pre-existing-sg"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + tags                   = {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:           + "Name" = "ex-rules-only-pre-existing-sg"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:         }
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + tags_all               = {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:           + "Example"    = "ex-rules-only"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:           + "Name"       = "ex-rules-only-pre-existing-sg"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:         }
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + vpc_id                 = "vpc-9ce7cafb"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"] will be created
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + description              = "ingress-http-80-tcp-from-sg-b551fece"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + from_port                = 80
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + id                       = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + self                     = false
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + source_security_group_id = "sg-b551fece"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + to_port                  = 80
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:       + type                     = "ingress"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: Plan: 2 to add, 0 to change, 0 to destroy.
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66: Changes to Outputs:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + auto_group_egress_to_public_internet_rule_ids      = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + auto_group_ingress_all_from_self_rule_ids          = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + auto_group_ingress_all_from_self_rule_keys         = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + computed_egress_rule_ids                           = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + computed_ingress_rule_ids                          = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + computed_managed_egress_rule_ids                   = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + computed_managed_ingress_rule_ids                  = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + egress_rule_keys                                   = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + ingress_rule_keys                                  = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + managed_egress_rule_keys                           = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + managed_ingress_rule_keys                          = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:19Z logger.go:66:   + pre_existing_sg_id                                 = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-24T04:34:20Z logger.go:66: aws_security_group.pre_existing_sg: Creating...
-TestTerraformRulesOnlyExample 2022-08-24T04:34:22Z logger.go:66: aws_security_group.pre_existing_sg: Creation complete after 2s [id=sg-00925330de67f46ad]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:22Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Creating...
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Creation complete after 1s [id=sgrule-316495495]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: Outputs:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: auto_group_egress_all_to_public_internet_rule_keys = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: auto_group_egress_to_public_internet_rule_ids = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: auto_group_ingress_all_from_self_rule_ids = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: auto_group_ingress_all_from_self_rule_keys = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: computed_egress_rule_ids = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: computed_ingress_rule_ids = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: computed_managed_egress_rule_ids = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: computed_managed_ingress_rule_ids = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: egress_rule_keys = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: ingress_rule_keys = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: managed_egress_rule_keys = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: managed_ingress_rule_keys = [
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66:   "ingress-http-80-tcp-from-sg-b551fece",
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: ]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: pre_existing_sg_id = "sg-00925330de67f46ad"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z retry.go:91: terraform [output -no-color -json ingress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:23Z logger.go:66: Running command terraform with args [output -no-color -json ingress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:24Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:24Z retry.go:91: terraform [output -no-color -json managed_ingress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:24Z logger.go:66: Running command terraform with args [output -no-color -json managed_ingress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:25Z logger.go:66: ["ingress-http-80-tcp-from-sg-b551fece"]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:25Z retry.go:91: terraform [output -no-color -json egress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:25Z logger.go:66: Running command terraform with args [output -no-color -json egress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:25Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:25Z retry.go:91: terraform [output -no-color -json managed_egress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:25Z logger.go:66: Running command terraform with args [output -no-color -json managed_egress_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:26Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:26Z retry.go:91: terraform [output -no-color -json computed_egress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:26Z logger.go:66: Running command terraform with args [output -no-color -json computed_egress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:27Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:27Z retry.go:91: terraform [output -no-color -json computed_ingress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:27Z logger.go:66: Running command terraform with args [output -no-color -json computed_ingress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:28Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:28Z retry.go:91: terraform [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:28Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_egress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:29Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:29Z retry.go:91: terraform [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:29Z logger.go:66: Running command terraform with args [output -no-color -json computed_managed_ingress_rule_ids]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:30Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:30Z retry.go:91: terraform [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:30Z logger.go:66: Running command terraform with args [output -no-color -json auto_group_egress_all_to_public_internet_rule_keys]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:30Z logger.go:66: []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:30Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:30Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:33Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-9ce7cafb]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: aws_security_group.pre_existing_sg: Refreshing state... [id=sg-00925330de67f46ad]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-b551fece]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Refreshing state... [id=sgrule-316495495]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - destroy
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: Terraform will perform the following actions:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   # aws_security_group.pre_existing_sg will be destroyed
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - resource "aws_security_group" "pre_existing_sg" {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:326504147071:security-group/sg-00925330de67f46ad" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - description            = "ex-rules-only-pre-existing-sg" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - egress                 = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - id                     = "sg-00925330de67f46ad" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - ingress                = [
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:           - {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - cidr_blocks      = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - description      = "ingress-http-80-tcp-from-sg-b551fece"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - from_port        = 80
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - protocol         = "tcp"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - security_groups  = [
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:                   - "sg-b551fece",
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:                 ]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - self             = false
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:               - to_port          = 80
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:             },
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:         ] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - name                   = "ex-rules-only-pre-existing-sg" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - owner_id               = "326504147071" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - tags                   = {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:           - "Name" = "ex-rules-only-pre-existing-sg"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:         } -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - tags_all               = {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:           - "Example"    = "ex-rules-only"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:           - "Name"       = "ex-rules-only-pre-existing-sg"
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:         } -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - vpc_id                 = "vpc-9ce7cafb" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   # module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"] will be destroyed
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - description              = "ingress-http-80-tcp-from-sg-b551fece" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - from_port                = 80 -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - id                       = "sgrule-316495495" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - security_group_id        = "sg-00925330de67f46ad" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - self                     = false -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - source_security_group_id = "sg-b551fece" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - to_port                  = 80 -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: Plan: 0 to add, 0 to change, 2 to destroy.
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66: Changes to Outputs:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - auto_group_egress_all_to_public_internet_rule_keys = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - auto_group_egress_to_public_internet_rule_ids      = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - auto_group_ingress_all_from_self_rule_ids          = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - auto_group_ingress_all_from_self_rule_keys         = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - computed_egress_rule_ids                           = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - computed_ingress_rule_ids                          = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - computed_managed_egress_rule_ids                   = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - computed_managed_ingress_rule_ids                  = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - egress_rule_keys                                   = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - ingress_rule_keys                                  = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - managed_egress_rule_keys                           = [] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - managed_ingress_rule_keys                          = [
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:       - "ingress-http-80-tcp-from-sg-b551fece",
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:     ] -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:34Z logger.go:66:   - pre_existing_sg_id                                 = "sg-00925330de67f46ad" -> null
-TestTerraformRulesOnlyExample 2022-08-24T04:34:35Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Destroying... [id=sgrule-316495495]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:36Z logger.go:66: module.security_group.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-b551fece"]: Destruction complete after 0s
-TestTerraformRulesOnlyExample 2022-08-24T04:34:36Z logger.go:66: aws_security_group.pre_existing_sg: Destroying... [id=sg-00925330de67f46ad]
-TestTerraformRulesOnlyExample 2022-08-24T04:34:37Z logger.go:66: aws_security_group.pre_existing_sg: Destruction complete after 1s
-TestTerraformRulesOnlyExample 2022-08-24T04:34:37Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-24T04:34:37Z logger.go:66: Destroy complete! Resources: 2 destroyed.
---- PASS: TestTerraformRulesOnlyExample (23.53s)
-PASS
-ok  	command-line-arguments	23.549s
+TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:08Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformRulesOnlyExample 2022-08-24T14:35:09Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:09Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformRulesOnlyExample 2022-08-24T14:35:09Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: [0m[32m
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: should now work.
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T14:35:10Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: An input variable with the name
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: An input variable with the name
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    apply.go:15:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_rules_only_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformRulesOnlyExample
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: An input variable with the name
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" has not been
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_https_from_public_internet_rules" {} block.
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: Error: Reference to undeclared input variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: An input variable with the name
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: declared. This variable can be declared with a variable
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" {} block.
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1;
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_https_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+Error: Reference to undeclared input variable
+
+  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+An input variable with the name
+"create_auto_group_ingress_http_from_public_internet_rules" has not been
+declared. This variable can be declared with a variable
+"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+    destroy.go:11:
+        	Error Trace:	/workspaces/terraform-aws-security-group/test/destroy.go:11
+        	            				/workspaces/terraform-aws-security-group/test/panic.go:642
+        	            				/workspaces/terraform-aws-security-group/test/testing.go:756
+        	            				/workspaces/terraform-aws-security-group/test/apply.go:15
+        	            				/workspaces/terraform-aws-security-group/test/terraform_rules_only_test.go:23
+        	Error:      	Received unexpected error:
+        	            	FatalError{Underlying: error while running command: exit status 1;
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 26, in resource "aws_security_group_rule" "auto_group_ingress_https_from_public_internet_rules":
+        	            	  26:   for_each = var.create && var.create_auto_group_ingress_https_from_public_internet_rules ? { "ingress-https-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_https_from_public_internet_rules" {} block.
+
+        	            	Error: Reference to undeclared input variable
+
+        	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+
+        	            	An input variable with the name
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
+        	            	declared. This variable can be declared with a variable
+        	            	"create_auto_group_ingress_http_from_public_internet_rules" {} block.}
+        	Test:       	TestTerraformRulesOnlyExample
+--- FAIL: TestTerraformRulesOnlyExample (5.81s)
+FAIL
+FAIL	command-line-arguments	5.835s
+FAIL

--- a/test/terraform_rules_only_test.log
+++ b/test/terraform_rules_only_test.log
@@ -34,7 +34,7 @@ TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
 TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
 TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66:
 TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: An input variable with the name
 TestTerraformRulesOnlyExample 2022-08-24T14:35:12Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -54,7 +54,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -78,7 +78,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -101,7 +101,7 @@ TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
 TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: Error: Reference to undeclared input variable
 TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
 TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:   44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66:
 TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: An input variable with the name
 TestTerraformRulesOnlyExample 2022-08-24T14:35:13Z logger.go:66: "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -121,7 +121,7 @@ declared. This variable can be declared with a variable
 Error: Reference to undeclared input variable
 
   on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
 An input variable with the name
 "create_auto_group_ingress_http_from_public_internet_rules" has not been
@@ -148,7 +148,7 @@ declared. This variable can be declared with a variable
         	            	Error: Reference to undeclared input variable
 
         	            	  on ../../auto_group_rules.tf line 44, in resource "aws_security_group_rule" "auto_group_ingress_http_from_public_internet_rules":
-        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-443-tcp-from-public-internet" = null } : {}
+        	            	  44:   for_each = var.create && var.create_auto_group_ingress_http_from_public_internet_rules ? { "ingress-http-80-tcp-from-public-internet" = null } : {}
 
         	            	An input variable with the name
         	            	"create_auto_group_ingress_http_from_public_internet_rules" has not been

--- a/variables.tf
+++ b/variables.tf
@@ -138,7 +138,19 @@ variable "computed_managed_egress_rules" {
 ###############################################################################
 
 variable "create_auto_group_ingress_all_from_self_rules" {
-  description = "Whether to create auto group ingress all to self rules."
+  description = "Whether to create auto group ingress all from self security group rules."
+  type        = bool
+  default     = false
+}
+
+variable "create_auto_group_ingress_https_from_public_internet_rules" {
+  description = "Whether to create auto group ingress HTTPS from the public internet rules."
+  type        = bool
+  default     = false
+}
+
+variable "create_auto_group_ingress_http_from_public_internet_rules" {
+  description = "Whether to create auto group ingress HTTP from the public internet rules."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
# Fixes

- renamed `ingress-all-from-self` to `ingress-all-all-from-self` for consistency with managed rule values.
- renamed `egress-all-to-public-internet` to `egress-all-all-to-public-internet` for consistency with managed rule values.

## Proposed Changes
- added auto group: `ingress-https-443-tcp-from-public-internet` 
- added auto group: `ingress-http-80-tcp-from-public-internet` 
- added `lint` at the end of the `tests` Makefile target
