### PR TITLE
remove-lookup-underscore-rule

### DIFF
--- a/.terraform-docs
+++ b/.terraform-docs
@@ -24,6 +24,16 @@ content: |-
 
   Please see the [Basic Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/basic) for more information.
 
+  ### Security Group with common rules
+
+  Create security groups with common scenario rules (e.g. `https`, `http`, and `ssh`).
+
+  ```hcl
+  {{ include "examples/common_rules/.main.tf.docs" }}
+  ```
+
+  Please see the [Common Rules Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/common_rules) for more information.
+
   ### Security Group with complete rules
 
   Create a security group with a combination of both managed, custom, computed, and auto group rules. This also demonstrates the conditional create functionality.
@@ -37,16 +47,6 @@ content: |-
   </details><br/>
 
   Please see the [Complete Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/complete) for more information.
-
-  ### Security Group with common rules
-
-  Create security groups with common scenario rules (e.g. `https`, `http`, and `ssh`).
-
-  ```hcl
-  {{ include "examples/common_rules/.main.tf.docs" }}
-  ```
-
-  Please see the [Common Rules Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/common_rules) for more information.
 
   ### Security group with custom rules
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,66 @@ module "sg" {
 
 Please see the [Basic Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/basic) for more information.
 
+### Security Group with common rules
+
+Create security groups with common scenario rules (e.g. `https`, `http`, and `ssh`).
+
+```hcl
+module "public_https_sg" {
+  source  = "aidanmelen/security-group-v2/aws"
+  version = ">= 0.5.0"
+
+  name        = "${local.name}-https"
+  description = "${local.name}-https"
+  vpc_id      = data.aws_vpc.default.id
+
+  create_ingress_https_from_public_rules = true
+  create_ingress_all_from_self_rule      = true
+  create_egress_all_to_public_rules      = true
+
+  tags = {
+    "Name" = "${local.name}-https"
+  }
+}
+
+module "public_http_sg" {
+  source  = "aidanmelen/security-group-v2/aws"
+  version = ">= 0.5.0"
+
+  name        = "${local.name}-http"
+  description = "${local.name}-http"
+  vpc_id      = data.aws_vpc.default.id
+
+  create_ingress_http_from_public_rules = true
+  create_ingress_all_from_self_rule     = true
+  create_egress_all_to_public_rules     = true
+
+  tags = {
+    "Name" = "${local.name}-http"
+  }
+}
+
+module "ssh_sg" {
+  source  = "aidanmelen/security-group-v2/aws"
+  version = ">= 0.5.0"
+
+  name        = "${local.name}-ssh"
+  description = "${local.name}-ssh"
+  vpc_id      = data.aws_vpc.default.id
+
+  managed_ingress_rules = [{ rule = "ssh-tcp", cidr_blocks = ["10.0.0.0/24"] }]
+
+  create_ingress_all_from_self_rule = true
+  create_egress_all_to_public_rules = true
+
+  tags = {
+    "Name" = "${local.name}-ssh"
+  }
+}
+```
+
+Please see the [Common Rules Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/common_rules) for more information.
+
 ### Security Group with complete rules
 
 Create a security group with a combination of both managed, custom, computed, and auto group rules. This also demonstrates the conditional create functionality.
@@ -183,66 +243,6 @@ module "disabled_sg" {
 </details><br/>
 
 Please see the [Complete Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/complete) for more information.
-
-### Security Group with common rules
-
-Create security groups with common scenario rules (e.g. `https`, `http`, and `ssh`).
-
-```hcl
-module "public_https_sg" {
-  source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
-
-  name        = "${local.name}-https"
-  description = "${local.name}-https"
-  vpc_id      = data.aws_vpc.default.id
-
-  create_ingress_https_from_public_rules = true
-  create_ingress_all_from_self_rule      = true
-  create_egress_all_to_public_rules      = true
-
-  tags = {
-    "Name" = "${local.name}-https"
-  }
-}
-
-module "public_http_sg" {
-  source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
-
-  name        = "${local.name}-http"
-  description = "${local.name}-http"
-  vpc_id      = data.aws_vpc.default.id
-
-  create_ingress_http_from_public_rules = true
-  create_ingress_all_from_self_rule     = true
-  create_egress_all_to_public_rules     = true
-
-  tags = {
-    "Name" = "${local.name}-http"
-  }
-}
-
-module "ssh_sg" {
-  source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
-
-  name        = "${local.name}-ssh"
-  description = "${local.name}-ssh"
-  vpc_id      = data.aws_vpc.default.id
-
-  managed_ingress_rules = [{ rule = "ssh-tcp", cidr_blocks = ["10.0.0.0/24"] }]
-
-  create_ingress_all_from_self_rule = true
-  create_egress_all_to_public_rules = true
-
-  tags = {
-    "Name" = "${local.name}-ssh"
-  }
-}
-```
-
-Please see the [Common Rules Example](https://github.com/aidanmelen/terraform-aws-security-group-v2/tree/main/examples/common_rules) for more information.
 
 ### Security group with custom rules
 
@@ -545,12 +545,12 @@ Run Terratest using the [Makefile](https://github.com/aidanmelen/terraform-aws-s
 ### Results
 
 ```
---- PASS: TestTerraformBasicExample (30.34s)
---- PASS: TestTerraformCompleteExample (55.77s)
---- PASS: TestTerraformCustomRulesExample (42.34s)
---- PASS: TestTerraformManagedRulesExample (41.20s)
---- PASS: TestTerraformComputedRulesExample (36.59s)
---- PASS: TestTerraformRulesOnlyExample (25.74s)
+--- PASS: TestTerraformBasicExample (28.83s)
+FAIL
+FAIL
+--- PASS: TestTerraformManagedRulesExample (41.35s)
+--- PASS: TestTerraformComputedRulesExample (41.60s)
+--- PASS: TestTerraformRulesOnlyExample (31.74s)
 ```
 
 ## Makefile Targets

--- a/bin/render-terraform-docs.sh
+++ b/bin/render-terraform-docs.sh
@@ -2,10 +2,10 @@
 
 # render terraform-docs code examples
 
-sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.0"/g' examples/basic/main.tf > examples/basic/.main.tf.docs
-sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.0"/g' examples/complete/main.tf > examples/complete/.main.tf.docs
-sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.0"/g' examples/common_rules/main.tf > examples/common_rules/.main.tf.docs
-sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.0"/g' examples/custom_rules/main.tf > examples/custom_rules/.main.tf.docs
-sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.0"/g' examples/managed_rules/main.tf > examples/managed_rules/.main.tf.docs
-sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.0"/g' examples/computed_rules/main.tf > examples/computed_rules/.main.tf.docs
-sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.0"/g' examples/rules_only/main.tf > examples/rules_only/.main.tf.docs
+sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.1"/g' examples/basic/main.tf > examples/basic/.main.tf.docs
+sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.1"/g' examples/complete/main.tf > examples/complete/.main.tf.docs
+sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.1"/g' examples/common_rules/main.tf > examples/common_rules/.main.tf.docs
+sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.1"/g' examples/custom_rules/main.tf > examples/custom_rules/.main.tf.docs
+sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.1"/g' examples/managed_rules/main.tf > examples/managed_rules/.main.tf.docs
+sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.1"/g' examples/computed_rules/main.tf > examples/computed_rules/.main.tf.docs
+sed -z 's/source = [^\r\n]*/source  = "aidanmelen\/security-group-v2\/aws"\n  version = ">= 0.5.1"/g' examples/rules_only/main.tf > examples/rules_only/.main.tf.docs

--- a/custom_rules.tf
+++ b/custom_rules.tf
@@ -22,8 +22,8 @@ locals {
     {
       for rule in var.ingress_rules : join("-", compact([
         "ingress",
-        lookup(rule, "to_port", null) == -1 ? "all" : lookup(rule, "to_port", null),
-        lookup(rule, "from_port", null) == -1 ? "all" : lookup(rule, "from_port", null),
+        contains([-1, 0], lookup(rule, "to_port", null)) ? "all" : lookup(rule, "to_port", null),
+        contains([-1, 0], lookup(rule, "from_port", null)) ? "all" : lookup(rule, "from_port", null),
         lookup(rule, "protocol", null) == "-1" ? "all" : lookup(rule, "protocol", null),
         "from",
         join(",", lookup(rule, "cidr_blocks", [])),
@@ -36,8 +36,8 @@ locals {
     {
       for rule in var.egress_rules : join("-", compact([
         "egress",
-        lookup(rule, "to_port", null) == -1 ? "all" : lookup(rule, "to_port", null),
-        lookup(rule, "from_port", null) == -1 ? "all" : lookup(rule, "from_port", null),
+        contains([-1, 0], lookup(rule, "to_port", null)) ? "all" : lookup(rule, "to_port", null),
+        contains([-1, 0], lookup(rule, "from_port", null)) ? "all" : lookup(rule, "from_port", null),
         lookup(rule, "protocol", null) == "-1" ? "all" : lookup(rule, "protocol", null),
         "to",
         join(",", lookup(rule, "cidr_blocks", [])),
@@ -50,8 +50,6 @@ locals {
   )
 
   # https://github.com/hashicorp/terraform/issues/28751
-  # The true and false result expressions must have consistent types. The given expressions are object and object, respectively.
-  # So we create objects with the same keys but with null values to satisfy this constraint.
   rules_false_expr = { for k, v in local.rules : k => null }
 }
 

--- a/examples/basic/.main.tf.docs
+++ b/examples/basic/.main.tf.docs
@@ -1,6 +1,6 @@
 module "sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = local.name
   description = local.name

--- a/examples/common_rules/.main.tf.docs
+++ b/examples/common_rules/.main.tf.docs
@@ -1,6 +1,6 @@
 module "public_https_sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = "${local.name}-https"
   description = "${local.name}-https"
@@ -17,7 +17,7 @@ module "public_https_sg" {
 
 module "public_http_sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = "${local.name}-http"
   description = "${local.name}-http"
@@ -34,7 +34,7 @@ module "public_http_sg" {
 
 module "ssh_sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = "${local.name}-ssh"
   description = "${local.name}-ssh"

--- a/examples/complete/.main.tf.docs
+++ b/examples/complete/.main.tf.docs
@@ -1,6 +1,6 @@
 module "sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = local.name
   description = local.name
@@ -112,6 +112,6 @@ module "sg" {
 
 module "disabled_sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
   create = false
 }

--- a/examples/computed_rules/.main.tf.docs
+++ b/examples/computed_rules/.main.tf.docs
@@ -29,7 +29,7 @@ resource "aws_ec2_managed_prefix_list" "other" {
 
 module "sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = local.name
   description = local.name

--- a/examples/custom_rules/.main.tf.docs
+++ b/examples/custom_rules/.main.tf.docs
@@ -1,6 +1,6 @@
 module "sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = local.name
   description = local.name

--- a/examples/managed_rules/.main.tf.docs
+++ b/examples/managed_rules/.main.tf.docs
@@ -1,6 +1,6 @@
 module "sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   name        = local.name
   description = local.name

--- a/examples/rules_only/.main.tf.docs
+++ b/examples/rules_only/.main.tf.docs
@@ -10,7 +10,7 @@ resource "aws_security_group" "pre_existing" {
 
 module "sg" {
   source  = "aidanmelen/security-group-v2/aws"
-  version = ">= 0.5.0"
+  version = ">= 0.5.1"
 
   create_sg         = false
   security_group_id = aws_security_group.pre_existing.id

--- a/managed_rules.tf
+++ b/managed_rules.tf
@@ -22,11 +22,11 @@ locals {
     {
       for rule in var.managed_ingress_rules : join("-", compact([
         "ingress",
-        lookup(rule, "rule", "_"),
+        rule["rule"],
         "from",
-        join(",", lookup(rule, "cidr_blocks", [])),
-        join(",", lookup(rule, "ipv6_cidr_blocks", [])),
-        join(",", lookup(rule, "prefix_list_ids", [])),
+        try(join(",", rule["cidr_blocks"]), ""),
+        try(join(",", rule["ipv6_cidr_blocks"]), ""),
+        try(join(",", rule["prefix_list_ids"]), ""),
         lookup(rule, "self", false) == true ? "self" : lookup(rule, "self", null),
         lookup(rule, "source_security_group_id", null)
       ])) => rule
@@ -34,11 +34,11 @@ locals {
     {
       for rule in var.managed_egress_rules : join("-", compact([
         "egress",
-        lookup(rule, "rule", "_"),
+        try(rule["rule"], "_"),
         "to",
-        join(",", lookup(rule, "cidr_blocks", [])),
-        join(",", lookup(rule, "ipv6_cidr_blocks", [])),
-        join(",", lookup(rule, "prefix_list_ids", [])),
+        try(join(",", rule["cidr_blocks"]), ""),
+        try(join(",", rule["ipv6_cidr_blocks"]), ""),
+        try(join(",", rule["prefix_list_ids"]), ""),
         lookup(rule, "self", false) == true ? "self" : lookup(rule, "self", null),
         lookup(rule, "source_security_group_id", null)
       ])) => rule
@@ -46,8 +46,6 @@ locals {
   )
 
   # https://github.com/hashicorp/terraform/issues/28751
-  # The true and false result expressions must have consistent types. The given expressions are object and object, respectively.
-  # So we create objects with the same keys but with null values to satisfy this constraint.
   managed_rules_false_expr = { for k, v in local.managed_rules : k => null }
 }
 

--- a/rules.tf
+++ b/rules.tf
@@ -197,7 +197,5 @@ locals {
     all-udp       = { "to_port" = 0, "from_port" = 65535, "protocol" = "udp" }
     all-icmp      = { "to_port" = 0, "from_port" = 0, "protocol" = "icmp" }
     all-ipv6-icmp = { "to_port" = 0, "from_port" = 0, "protocol" = 58 }
-    # This is a fallback rule to pass to lookup() as default. It does not open anything, because it should never be used.
-    _ = ["", "", ""]
   }
 }

--- a/test/.terratest.docs
+++ b/test/.terratest.docs
@@ -1,6 +1,6 @@
---- PASS: TestTerraformBasicExample (30.34s)
---- PASS: TestTerraformCompleteExample (55.77s)
---- PASS: TestTerraformCustomRulesExample (42.34s)
---- PASS: TestTerraformManagedRulesExample (41.20s)
---- PASS: TestTerraformComputedRulesExample (36.59s)
---- PASS: TestTerraformRulesOnlyExample (25.74s)
+--- PASS: TestTerraformBasicExample (28.83s)
+FAIL
+FAIL
+--- PASS: TestTerraformManagedRulesExample (41.35s)
+--- PASS: TestTerraformComputedRulesExample (41.60s)
+--- PASS: TestTerraformRulesOnlyExample (31.74s)

--- a/test/terraform_basic_test.log
+++ b/test/terraform_basic_test.log
@@ -1,502 +1,502 @@
 === RUN   TestTerraformBasicExample
-TestTerraformBasicExample 2022-08-26T17:21:13Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformBasicExample 2022-08-26T17:21:13Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformBasicExample 2022-08-26T17:21:13Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformBasicExample 2022-08-26T17:21:13Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:13Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformBasicExample 2022-08-26T17:21:14Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:14Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformBasicExample 2022-08-26T17:21:14Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: [0m[32m
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: should now work.
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformBasicExample 2022-08-26T17:21:16Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:16Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + create
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66: Terraform will perform the following actions:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + description            = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + id                     = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + name                   = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + tags                   = {
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "Name" = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + tags_all               = {
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "Example"    = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "Name"       = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + timeouts {
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + create = "10m"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + delete = "15m"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be created
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + resource "aws_security_group_rule" "egress_all_to_public_rules" {
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + cidr_blocks              = [
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:         ]
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + from_port                = 0
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + id                       = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "::/0",
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:         ]
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + protocol                 = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + self                     = false
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + to_port                  = 0
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + type                     = "egress"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   # module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"] will be created
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + resource "aws_security_group_rule" "ingress_all_from_self_rule" {
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + description              = "Opening up ingress all ports from self security group."
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + from_port                = 0
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + id                       = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + protocol                 = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + self                     = true
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + to_port                  = 0
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + type                     = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be created
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + cidr_blocks              = [
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:           + "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:         ]
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + description              = "My Service"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + from_port                = 443
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + id                       = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + self                     = false
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + to_port                  = 443
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:       + type                     = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66: Plan: 4 to add, 0 to change, 0 to destroy.
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66: Changes to Outputs:
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + arn          = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + egress       = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + egress_keys  = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + id           = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + ingress      = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:19Z logger.go:66:   + ingress_keys = (known after apply)
-TestTerraformBasicExample 2022-08-26T17:21:20Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
-TestTerraformBasicExample 2022-08-26T17:21:23Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 2s [id=sg-1111111111111111]
-TestTerraformBasicExample 2022-08-26T17:21:23Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Creating...
-TestTerraformBasicExample 2022-08-26T17:21:23Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creating...
-TestTerraformBasicExample 2022-08-26T17:21:23Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creating...
-TestTerraformBasicExample 2022-08-26T17:21:23Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:24Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creation complete after 2s [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creation complete after 2s [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: Outputs:
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: egress = {
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   "egress-all-all-to-public" = {
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:       "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     ])
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "from_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:       "::/0",
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     ])
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "protocol" = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "self" = false
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "to_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "type" = "egress"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   }
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: }
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: egress_keys = [
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   "egress-all-all-to-public",
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: ingress = {
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   "ingress-all-all-from-self" = {
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "description" = "Opening up ingress all ports from self security group."
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "from_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "protocol" = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "self" = true
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "to_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "type" = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   }
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24" = {
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:       "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     ])
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "description" = "My Service"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "from_port" = 443
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "protocol" = "tcp"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "self" = false
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "to_port" = 443
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:     "type" = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   }
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: }
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: ingress_keys = [
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   "ingress-all-all-from-self",
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-26T17:21:25Z retry.go:91: terraform [output -no-color -json ingress_keys]
-TestTerraformBasicExample 2022-08-26T17:21:25Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
-TestTerraformBasicExample 2022-08-26T17:21:26Z logger.go:66: ["ingress-all-all-from-self","ingress-https-443-tcp-from-10.0.0.0/24"]
-TestTerraformBasicExample 2022-08-26T17:21:26Z retry.go:91: terraform [output -no-color -json egress_keys]
-TestTerraformBasicExample 2022-08-26T17:21:26Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
-TestTerraformBasicExample 2022-08-26T17:21:27Z logger.go:66: ["egress-all-all-to-public"]
-TestTerraformBasicExample 2022-08-26T17:21:27Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:27Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:30Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformBasicExample 2022-08-26T17:21:30Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformBasicExample 2022-08-26T17:21:30Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformBasicExample 2022-08-26T17:21:30Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:30Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:30Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:31Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:31Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformBasicExample 2022-08-26T17:21:31Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:31Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformBasicExample 2022-08-26T17:21:31Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: Outputs:
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: egress = {
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   "egress-all-all-to-public" = {
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:       "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     ])
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "from_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:       "::/0",
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     ])
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "protocol" = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "self" = false
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "to_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "type" = "egress"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   }
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: }
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: egress_keys = [
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   "egress-all-all-to-public",
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: ingress = {
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   "ingress-all-all-from-self" = {
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "description" = "Opening up ingress all ports from self security group."
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "from_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "protocol" = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "self" = true
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "to_port" = 0
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "type" = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   }
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24" = {
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:       "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     ])
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "description" = "My Service"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "from_port" = 443
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "protocol" = "tcp"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "self" = false
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "to_port" = 443
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:     "type" = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   }
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: }
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: ingress_keys = [
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   "ingress-all-all-from-self",
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: ]
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:32Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformBasicExample 2022-08-26T17:21:35Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:35Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformBasicExample 2022-08-26T17:21:38Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - destroy
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: Terraform will perform the following actions:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - description            = "ex-basic" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - egress                 = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - cidr_blocks      = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:                   - "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:                 ]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - from_port        = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:                   - "::/0",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:                 ]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - protocol         = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - security_groups  = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - self             = false
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - to_port          = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:             },
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - ingress                = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - cidr_blocks      = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:                   - "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:                 ]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - description      = "My Service"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - from_port        = 443
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - protocol         = "tcp"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - security_groups  = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - self             = false
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - to_port          = 443
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:             },
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - cidr_blocks      = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - description      = "Opening up ingress all ports from self security group."
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - from_port        = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - protocol         = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - security_groups  = []
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - self             = true
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - to_port          = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:             },
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - name                   = "ex-basic" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - tags                   = {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "Name" = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         } -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - tags_all               = {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "Example"    = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "Name"       = "ex-basic"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         } -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - timeouts {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - create = "10m" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - delete = "15m" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be destroyed
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - resource "aws_security_group_rule" "egress_all_to_public_rules" {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - cidr_blocks       = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "::/0",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - self              = false -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - type              = "egress" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   # module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"] will be destroyed
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - resource "aws_security_group_rule" "ingress_all_from_self_rule" {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - description       = "Opening up ingress all ports from self security group." -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - self              = true -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be destroyed
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - cidr_blocks       = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         ] -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - description       = "My Service" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - self              = false -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: Plan: 0 to add, 0 to change, 4 to destroy.
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66: Changes to Outputs:
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - egress       = {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - egress-all-all-to-public = {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - cidr_blocks              = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - "0.0.0.0/0",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:             ]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - from_port                = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - "::/0",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:             ]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - protocol                 = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - self                     = false
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - source_security_group_id = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - timeouts                 = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - to_port                  = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - type                     = "egress"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     } -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - egress_keys  = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - "egress-all-all-to-public",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     ] -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - id           = "sg-1111111111111111" -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - ingress      = {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - ingress-all-all-from-self                = {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - cidr_blocks              = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - description              = "Opening up ingress all ports from self security group."
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - from_port                = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - protocol                 = "-1"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - self                     = true
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - source_security_group_id = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - timeouts                 = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - to_port                  = 0
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - type                     = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - "ingress-https-443-tcp-from-10.0.0.0/24" = {
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - cidr_blocks              = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:               - "10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:             ]
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - description              = "My Service"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - from_port                = 443
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - self                     = false
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - source_security_group_id = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - timeouts                 = null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - to_port                  = 443
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:           - type                     = "ingress"
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:         }
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     } -> null
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:   - ingress_keys = [
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - "ingress-all-all-from-self",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:       - "ingress-https-443-tcp-from-10.0.0.0/24",
-TestTerraformBasicExample 2022-08-26T17:21:39Z logger.go:66:     ] -> null
-TestTerraformBasicExample 2022-08-26T17:21:40Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destroying... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:40Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destroying... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:40Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Destroying... [id=sgrule-1111111111]
-TestTerraformBasicExample 2022-08-26T17:21:41Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destruction complete after 0s
-TestTerraformBasicExample 2022-08-26T17:21:42Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Destruction complete after 1s
-TestTerraformBasicExample 2022-08-26T17:21:42Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destruction complete after 2s
-TestTerraformBasicExample 2022-08-26T17:21:42Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
-TestTerraformBasicExample 2022-08-26T17:21:43Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformBasicExample 2022-08-26T17:21:43Z logger.go:66:
-TestTerraformBasicExample 2022-08-26T17:21:43Z logger.go:66: Destroy complete! Resources: 4 destroyed.
---- PASS: TestTerraformBasicExample (30.34s)
+TestTerraformBasicExample 2022-08-26T22:27:36Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformBasicExample 2022-08-26T22:27:36Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformBasicExample 2022-08-26T22:27:36Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformBasicExample 2022-08-26T22:27:36Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:36Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformBasicExample 2022-08-26T22:27:37Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:37Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformBasicExample 2022-08-26T22:27:37Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: [0m[32m
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: should now work.
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformBasicExample 2022-08-26T22:27:38Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:38Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + create
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66: Terraform will perform the following actions:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + description            = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + id                     = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + name                   = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + tags                   = {
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "Name" = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + tags_all               = {
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "Example"    = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "Name"       = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + timeouts {
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + create = "10m"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + delete = "15m"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be created
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + resource "aws_security_group_rule" "egress_all_to_public_rules" {
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + cidr_blocks              = [
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:         ]
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + from_port                = 0
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + id                       = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "::/0",
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:         ]
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + protocol                 = "-1"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + self                     = false
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + to_port                  = 0
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + type                     = "egress"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   # module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"] will be created
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + resource "aws_security_group_rule" "ingress_all_from_self_rule" {
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + description              = "Opening up ingress all ports from self security group."
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + from_port                = 0
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + id                       = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + protocol                 = "-1"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + self                     = true
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + to_port                  = 0
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + type                     = "ingress"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be created
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + cidr_blocks              = [
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:           + "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:         ]
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + description              = "My Service"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + from_port                = 443
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + id                       = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + self                     = false
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + to_port                  = 443
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:       + type                     = "ingress"
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66: Plan: 4 to add, 0 to change, 0 to destroy.
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66: Changes to Outputs:
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + arn          = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + egress       = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + egress_keys  = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + id           = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + ingress      = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:41Z logger.go:66:   + ingress_keys = (known after apply)
+TestTerraformBasicExample 2022-08-26T22:27:42Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
+TestTerraformBasicExample 2022-08-26T22:27:45Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 2s [id=sg-1111111111111111]
+TestTerraformBasicExample 2022-08-26T22:27:45Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Creating...
+TestTerraformBasicExample 2022-08-26T22:27:45Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creating...
+TestTerraformBasicExample 2022-08-26T22:27:45Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creating...
+TestTerraformBasicExample 2022-08-26T22:27:45Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Creation complete after 1s [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:46Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Creation complete after 2s [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creation complete after 2s [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: Outputs:
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: egress = {
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   "egress-all-all-to-public" = {
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:       "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     ])
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "from_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:       "::/0",
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     ])
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "protocol" = "-1"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "self" = false
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "to_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "type" = "egress"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   }
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: }
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: egress_keys = [
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   "egress-all-all-to-public",
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: ]
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: ingress = {
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   "ingress-all-all-from-self" = {
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "description" = "Opening up ingress all ports from self security group."
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "from_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "protocol" = "-1"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "self" = true
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "to_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "type" = "ingress"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   }
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24" = {
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:       "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     ])
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "description" = "My Service"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "from_port" = 443
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "protocol" = "tcp"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "self" = false
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "to_port" = 443
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:     "type" = "ingress"
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   }
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: }
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: ingress_keys = [
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   "ingress-all-all-from-self",
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: ]
+TestTerraformBasicExample 2022-08-26T22:27:47Z retry.go:91: terraform [output -no-color -json ingress_keys]
+TestTerraformBasicExample 2022-08-26T22:27:47Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
+TestTerraformBasicExample 2022-08-26T22:27:48Z logger.go:66: ["ingress-all-all-from-self","ingress-https-443-tcp-from-10.0.0.0/24"]
+TestTerraformBasicExample 2022-08-26T22:27:48Z retry.go:91: terraform [output -no-color -json egress_keys]
+TestTerraformBasicExample 2022-08-26T22:27:48Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
+TestTerraformBasicExample 2022-08-26T22:27:48Z logger.go:66: ["egress-all-all-to-public"]
+TestTerraformBasicExample 2022-08-26T22:27:49Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:49Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:51Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformBasicExample 2022-08-26T22:27:52Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: Outputs:
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: egress = {
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   "egress-all-all-to-public" = {
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:       "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     ])
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "from_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:       "::/0",
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     ])
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "protocol" = "-1"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "self" = false
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "to_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "type" = "egress"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   }
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: }
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: egress_keys = [
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   "egress-all-all-to-public",
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: ]
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: ingress = {
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   "ingress-all-all-from-self" = {
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "description" = "Opening up ingress all ports from self security group."
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "from_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "protocol" = "-1"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "self" = true
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "to_port" = 0
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "type" = "ingress"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   }
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24" = {
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:       "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     ])
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "description" = "My Service"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "from_port" = 443
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "protocol" = "tcp"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "self" = false
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "to_port" = 443
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:     "type" = "ingress"
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   }
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: }
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: ingress_keys = [
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   "ingress-all-all-from-self",
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66:   "ingress-https-443-tcp-from-10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: ]
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:53Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:56Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformBasicExample 2022-08-26T22:27:56Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformBasicExample 2022-08-26T22:27:56Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformBasicExample 2022-08-26T22:27:56Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:56Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:27:57Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:57Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformBasicExample 2022-08-26T22:27:57Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:27:57Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformBasicExample 2022-08-26T22:27:57Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformBasicExample 2022-08-26T22:27:57Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:57Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformBasicExample 2022-08-26T22:27:59Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformBasicExample 2022-08-26T22:28:00Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformBasicExample 2022-08-26T22:28:00Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformBasicExample 2022-08-26T22:28:00Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:28:00Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:28:00Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - destroy
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66: Terraform will perform the following actions:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - description            = "ex-basic" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - egress                 = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - cidr_blocks      = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:                   - "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:                 ]
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - from_port        = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:                   - "::/0",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:                 ]
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - protocol         = "-1"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - security_groups  = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - self             = false
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - to_port          = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:             },
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - ingress                = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - cidr_blocks      = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:                   - "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:                 ]
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - description      = "My Service"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - from_port        = 443
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - protocol         = "tcp"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - security_groups  = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - self             = false
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - to_port          = 443
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:             },
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - cidr_blocks      = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - description      = "Opening up ingress all ports from self security group."
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - from_port        = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - protocol         = "-1"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - security_groups  = []
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - self             = true
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - to_port          = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:             },
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - name                   = "ex-basic" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - tags                   = {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "Name" = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         } -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - tags_all               = {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "Example"    = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "Name"       = "ex-basic"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         } -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - timeouts {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - create = "10m" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - delete = "15m" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be destroyed
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - resource "aws_security_group_rule" "egress_all_to_public_rules" {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - cidr_blocks       = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "::/0",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - self              = false -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - type              = "egress" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   # module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"] will be destroyed
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - resource "aws_security_group_rule" "ingress_all_from_self_rule" {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - description       = "Opening up ingress all ports from self security group." -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - self              = true -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"] will be destroyed
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - cidr_blocks       = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         ] -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - description       = "My Service" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - self              = false -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66: Plan: 0 to add, 0 to change, 4 to destroy.
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66: Changes to Outputs:
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - egress       = {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - egress-all-all-to-public = {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - cidr_blocks              = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - "0.0.0.0/0",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:             ]
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - from_port                = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - "::/0",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:             ]
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - protocol                 = "-1"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - self                     = false
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - source_security_group_id = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - timeouts                 = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - to_port                  = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - type                     = "egress"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     } -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - egress_keys  = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - "egress-all-all-to-public",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     ] -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - id           = "sg-1111111111111111" -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - ingress      = {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - ingress-all-all-from-self                = {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - cidr_blocks              = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - description              = "Opening up ingress all ports from self security group."
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - from_port                = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - protocol                 = "-1"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - self                     = true
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - source_security_group_id = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - timeouts                 = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - to_port                  = 0
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - type                     = "ingress"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - "ingress-https-443-tcp-from-10.0.0.0/24" = {
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - cidr_blocks              = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:               - "10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:             ]
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - description              = "My Service"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - from_port                = 443
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - self                     = false
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - source_security_group_id = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - timeouts                 = null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - to_port                  = 443
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:           - type                     = "ingress"
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:         }
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     } -> null
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:   - ingress_keys = [
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - "ingress-all-all-from-self",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:       - "ingress-https-443-tcp-from-10.0.0.0/24",
+TestTerraformBasicExample 2022-08-26T22:28:01Z logger.go:66:     ] -> null
+TestTerraformBasicExample 2022-08-26T22:28:02Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Destroying... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:28:02Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destroying... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:28:02Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destroying... [id=sgrule-1111111111]
+TestTerraformBasicExample 2022-08-26T22:28:02Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destruction complete after 1s
+TestTerraformBasicExample 2022-08-26T22:28:03Z logger.go:66: module.sg.aws_security_group_rule.ingress_all_from_self_rule["ingress-all-all-from-self"]: Destruction complete after 1s
+TestTerraformBasicExample 2022-08-26T22:28:04Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-https-443-tcp-from-10.0.0.0/24"]: Destruction complete after 2s
+TestTerraformBasicExample 2022-08-26T22:28:04Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
+TestTerraformBasicExample 2022-08-26T22:28:05Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformBasicExample 2022-08-26T22:28:05Z logger.go:66:
+TestTerraformBasicExample 2022-08-26T22:28:05Z logger.go:66: Destroy complete! Resources: 4 destroyed.
+--- PASS: TestTerraformBasicExample (28.83s)
 PASS
-ok  	command-line-arguments	30.359s
+ok  	command-line-arguments	28.842s

--- a/test/terraform_complete_test.log
+++ b/test/terraform_complete_test.log
@@ -1,1864 +1,1893 @@
 === RUN   TestTerraformCompleteExample
-TestTerraformCompleteExample 2022-08-26T17:21:45Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-26T17:21:45Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformCompleteExample 2022-08-26T17:21:45Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformCompleteExample 2022-08-26T17:21:45Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:45Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformCompleteExample 2022-08-26T17:21:46Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:46Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformCompleteExample 2022-08-26T17:21:46Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: [0m[32m
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: should now work.
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformCompleteExample 2022-08-26T17:21:47Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:21:47Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:21:49Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:21:49Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-26T17:21:49Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + create
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + address_family = "IPv4"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + arn            = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id             = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + max_entries    = 5
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + name           = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + owner_id       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + tags_all       = {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + version        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + entry {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + cidr        = "172.31.0.0/16"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + description = "Primary"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # aws_security_group.other will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group" "other" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description            = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + name                   = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + tags                   = {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "Name" = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + tags_all               = {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "Name"       = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description            = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + name                   = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + tags                   = {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "Name" = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + tags_all               = {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "Name"       = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + timeouts {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + create = "10m"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + delete = "15m"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 80
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 80
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 80
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 80
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "egress_all_to_public_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "::/0",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 443
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 443
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 5432
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 5432
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 22
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 22
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 5432
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 5432
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 22
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:           + "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:         ]
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 22
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "egress-0-0-all-to-self"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = true
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "ingress-0-0-all-from-self"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = true
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"] will be created
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + description              = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + self                     = false
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: Plan: 18 to add, 0 to change, 0 to destroy.
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66: Changes to Outputs:
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + arn            = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + disabled_sg_id = "I was not created"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + egress         = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + egress_keys    = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + id             = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + ingress        = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + ingress_keys   = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:   + terratest      = {
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + aws_ec2_managed_prefix_list_other_id = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + aws_security_group_other_id          = (known after apply)
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + data_aws_prefix_list_private_s3_id   = "pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:       + data_aws_security_group_default_id   = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:21:50Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:21:51Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:51Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:51Z logger.go:66: aws_security_group.other: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:52Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 2s [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:53Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:54Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:54Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:55Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:55Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:55Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creation complete after 2s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:55Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:56Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Creation complete after 3s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:56Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:57Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 3s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:57Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creating...
-TestTerraformCompleteExample 2022-08-26T17:21:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creation complete after 4s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:59Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creation complete after 5s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:21:59Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Creation complete after 6s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:00Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 6s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:01Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Creation complete after 7s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:01Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 7s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:02Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 8s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:03Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 7s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 7s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 8s [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: Apply complete! Resources: 18 added, 0 changed, 0 destroyed.
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: Outputs:
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: disabled_sg_id = "I was not created"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: egress = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-0-0-all-to-self" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "egress-0-0-all-to-self"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = true
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-all-all-to-public" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "::/0",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: egress_keys = [
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-0-0-all-to-self",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-all-all-to-public",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: ingress = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-0-0-all-from-self" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "ingress-0-0-all-from-self"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = true
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "from_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "to_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: ingress_keys = [
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-0-0-all-from-self",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: terratest = {
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: }
-TestTerraformCompleteExample 2022-08-26T17:22:04Z retry.go:91: terraform [output -no-color -json terratest]
-TestTerraformCompleteExample 2022-08-26T17:22:04Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
-TestTerraformCompleteExample 2022-08-26T17:22:05Z logger.go:66: {"aws_ec2_managed_prefix_list_other_id":"pl-1111111111","aws_security_group_other_id":"sg-1111111111111111","data_aws_prefix_list_private_s3_id":"pl-1111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
-TestTerraformCompleteExample 2022-08-26T17:22:05Z retry.go:91: terraform [output -no-color -json ingress_keys]
-TestTerraformCompleteExample 2022-08-26T17:22:05Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
-TestTerraformCompleteExample 2022-08-26T17:22:06Z logger.go:66: ["ingress-0-0-all-from-self","ingress-0-0-icmp-from-sg-1111111111111111","ingress-443-443-tcp-from-sg-1111111111111111","ingress-80-80-tcp-from-sg-1111111111111111","ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-1111111111"]
-TestTerraformCompleteExample 2022-08-26T17:22:06Z retry.go:91: terraform [output -no-color -json egress_keys]
-TestTerraformCompleteExample 2022-08-26T17:22:06Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
-TestTerraformCompleteExample 2022-08-26T17:22:07Z logger.go:66: ["egress-0-0-all-to-self","egress-0-0-icmp-to-sg-1111111111111111","egress-443-443-tcp-to-pl-1111111111","egress-80-80-tcp-to-pl-1111111111","egress-all-all-to-public","egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-1111111111"]
-TestTerraformCompleteExample 2022-08-26T17:22:07Z retry.go:91: terraform [output -no-color -json disabled_sg_id]
-TestTerraformCompleteExample 2022-08-26T17:22:07Z logger.go:66: Running command terraform with args [output -no-color -json disabled_sg_id]
-TestTerraformCompleteExample 2022-08-26T17:22:08Z logger.go:66: "I was not created"
-TestTerraformCompleteExample 2022-08-26T17:22:08Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:22:08Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:11Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformCompleteExample 2022-08-26T17:22:12Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: Outputs:
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: disabled_sg_id = "I was not created"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: egress = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-0-0-all-to-self" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "egress-0-0-all-to-self"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = true
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-all-all-to-public" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "::/0",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: egress_keys = [
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-0-0-all-to-self",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-all-all-to-public",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: ingress = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-0-0-all-from-self" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "ingress-0-0-all-from-self"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = true
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 443
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 80
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 0
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "from_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:       "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     ])
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "self" = false
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "to_port" = 22
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:     "type" = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: ingress_keys = [
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-0-0-all-from-self",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: ]
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: terratest = {
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: }
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:22:13Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:16Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformCompleteExample 2022-08-26T17:22:17Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:22:17Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:20Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - destroy
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - address_family = "IPv4" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:111111111111:prefix-list/pl-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id             = "pl-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - max_entries    = 5 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - name           = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - owner_id       = "111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - tags           = {} -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - tags_all       = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - version        = 1 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - entry {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description = "Primary" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # aws_security_group.other will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group" "other" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description            = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress                 = [] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ingress                = [] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - name                   = "ex-complete-other" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - tags                   = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "Name" = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - tags_all               = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "Name"       = "ex-complete-other"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description            = "ex-complete" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress                 = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "::/0",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "egress-0-0-all-to-self"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = true
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ingress                = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "ingress-0-0-all-from-self"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = true
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - from_port        = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                   - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:                 ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - security_groups  = []
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - self             = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - to_port          = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             },
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - name                   = "ex-complete" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - tags                   = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "Name" = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - tags_all               = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "Example"    = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "Name"       = "ex-complete"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - timeouts {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - create = "10m" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - delete = "15m" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "Managed by Terraform" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 80 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 80 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description              = "Managed by Terraform" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port                = 80 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port                  = 80 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "https-443-tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description              = "https-443-tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port                = 443 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port                  = 443 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "egress_all_to_public_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "::/0",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "egress-0-0-all-to-self" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = true -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description              = "egress-0-0-icmp-to-sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port                = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port                  = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type                     = "egress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description       = "ingress-0-0-all-from-self" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self              = true -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"] will be destroyed
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - description              = "ingress-0-0-icmp-from-sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - from_port                = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - self                     = false -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - to_port                  = 0 -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: Plan: 0 to add, 0 to change, 18 to destroy.
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66: Changes to Outputs:
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - arn            = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - disabled_sg_id = "I was not created" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - egress         = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress-0-0-all-to-self                              = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "egress-0-0-all-to-self"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = true
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress-0-0-icmp-to-sg-1111111111111111                      = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress-443-443-tcp-to-pl-1111111111          = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress-80-80-tcp-to-pl-1111111111            = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress-all-all-to-public                            = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "0.0.0.0/0",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "::/0",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64"            = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - egress-ssh-tcp-to-pl-1111111111                       = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "egress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - egress_keys    = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-0-0-all-to-self",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-0-0-icmp-to-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-443-443-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-80-80-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-all-all-to-public",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "egress-ssh-tcp-to-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - id             = "sg-1111111111111111" -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - ingress        = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ingress-0-0-all-from-self                        = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "ingress-0-0-all-from-self"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = true
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ingress-0-0-icmp-from-sg-1111111111111111                = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "icmp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ingress-443-443-tcp-from-sg-1111111111111111    = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "https-443-tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 443
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ingress-80-80-tcp-from-sg-1111111111111111      = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "Managed by Terraform"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 80
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "10.10.0.0/16",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "-1"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 0
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64"      = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 5432
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - ingress-ssh-tcp-from-pl-1111111111                 = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - description              = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - from_port                = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:               - "pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:             ]
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - self                     = false
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - source_security_group_id = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - timeouts                 = null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - to_port                  = 22
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:           - type                     = "ingress"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:         }
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - ingress_keys   = [
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-0-0-all-from-self",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-0-0-icmp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-443-443-tcp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-80-80-tcp-from-sg-1111111111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - "ingress-ssh-tcp-from-pl-1111111111",
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     ] -> null
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:   - terratest      = {
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - aws_ec2_managed_prefix_list_other_id = "pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - aws_security_group_other_id          = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - data_aws_prefix_list_private_s3_id   = "pl-1111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:       - data_aws_security_group_default_id   = "sg-1111111111111111"
-TestTerraformCompleteExample 2022-08-26T17:22:21Z logger.go:66:     } -> null
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:23Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destruction complete after 0s
-TestTerraformCompleteExample 2022-08-26T17:22:23Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:23Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-26T17:22:23Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:24Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 2s
-TestTerraformCompleteExample 2022-08-26T17:22:24Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:25Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 2s
-TestTerraformCompleteExample 2022-08-26T17:22:25Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:26Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Destruction complete after 3s
-TestTerraformCompleteExample 2022-08-26T17:22:26Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:26Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 4s
-TestTerraformCompleteExample 2022-08-26T17:22:27Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 5s
-TestTerraformCompleteExample 2022-08-26T17:22:28Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Destruction complete after 5s
-TestTerraformCompleteExample 2022-08-26T17:22:29Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 6s
-TestTerraformCompleteExample 2022-08-26T17:22:30Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-26T17:22:30Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 8s
-TestTerraformCompleteExample 2022-08-26T17:22:31Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-26T17:22:32Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-26T17:22:32Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Destruction complete after 8s
-TestTerraformCompleteExample 2022-08-26T17:22:33Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 8s
-TestTerraformCompleteExample 2022-08-26T17:22:33Z logger.go:66: aws_security_group.other: Destroying... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:33Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-1111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:33Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
-TestTerraformCompleteExample 2022-08-26T17:22:34Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-26T17:22:35Z logger.go:66: aws_security_group.other: Destruction complete after 1s
-TestTerraformCompleteExample 2022-08-26T17:22:40Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
-TestTerraformCompleteExample 2022-08-26T17:22:40Z logger.go:66:
-TestTerraformCompleteExample 2022-08-26T17:22:40Z logger.go:66: Destroy complete! Resources: 18 destroyed.
---- PASS: TestTerraformCompleteExample (55.77s)
-PASS
-ok  	command-line-arguments	55.783s
+TestTerraformCompleteExample 2022-08-26T22:28:06Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-26T22:28:06Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformCompleteExample 2022-08-26T22:28:06Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformCompleteExample 2022-08-26T22:28:06Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:06Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformCompleteExample 2022-08-26T22:28:07Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:07Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformCompleteExample 2022-08-26T22:28:07Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: [0m[32m
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: should now work.
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformCompleteExample 2022-08-26T22:28:08Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:08Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + create
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + address_family = "IPv4"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + arn            = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id             = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + max_entries    = 5
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + name           = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + owner_id       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + tags_all       = {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + version        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + entry {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + cidr        = "172.31.0.0/16"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + description = "Primary"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # aws_security_group.other will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group" "other" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description            = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + name                   = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + tags                   = {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "Name" = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + tags_all               = {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "Name"       = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description            = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + name                   = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + tags                   = {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "Name" = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + tags_all               = {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "Name"       = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + timeouts {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + create = "10m"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + delete = "15m"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 80
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 80
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 80
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 80
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "egress_all_to_public_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "::/0",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 443
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 443
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 22
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 22
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 22
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:           + "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:         ]
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 22
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = true
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = true
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"] will be created
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: Plan: 18 to add, 0 to change, 0 to destroy.
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66: Changes to Outputs:
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + arn            = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + disabled_sg_id = "I was not created"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + egress         = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + egress_keys    = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + id             = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + ingress        = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + ingress_keys   = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:   + terratest      = {
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + aws_ec2_managed_prefix_list_other_id = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + aws_security_group_other_id          = (known after apply)
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + data_aws_prefix_list_private_s3_id   = "pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:       + data_aws_security_group_default_id   = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:11Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:13Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:13Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:13Z logger.go:66: aws_security_group.other: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:14Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 2s [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:15Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:16Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creation complete after 1s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:16Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 2s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:17Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 3s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:17Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:18Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Creation complete after 4s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:18Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:19Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Creation complete after 4s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:19Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
+TestTerraformCompleteExample 2022-08-26T22:28:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 5s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:20Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Creation complete after 6s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:21Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 7s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:23Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:24Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:24Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:25Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:26Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: Apply complete! Resources: 18 added, 0 changed, 0 destroyed.
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: Outputs:
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: disabled_sg_id = "I was not created"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: egress = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-all-all-all-to-self" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = true
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-all-all-to-public" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "::/0",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: egress_keys = [
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-all-all-all-to-self",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-all-all-to-public",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: ingress = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-all-all-all-from-self" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = true
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "from_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "to_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: ingress_keys = [
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-all-all-all-from-self",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: terratest = {
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: }
+TestTerraformCompleteExample 2022-08-26T22:28:27Z retry.go:91: terraform [output -no-color -json terratest]
+TestTerraformCompleteExample 2022-08-26T22:28:27Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
+TestTerraformCompleteExample 2022-08-26T22:28:28Z logger.go:66: {"aws_ec2_managed_prefix_list_other_id":"pl-1111111111","aws_security_group_other_id":"sg-1111111111111111","data_aws_prefix_list_private_s3_id":"pl-1111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
+TestTerraformCompleteExample 2022-08-26T22:28:28Z retry.go:91: terraform [output -no-color -json ingress_keys]
+TestTerraformCompleteExample 2022-08-26T22:28:28Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
+TestTerraformCompleteExample 2022-08-26T22:28:29Z logger.go:66: ["ingress-443-443-tcp-from-sg-1111111111111111","ingress-80-80-tcp-from-sg-1111111111111111","ingress-all-all-all-from-self","ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-all-all-icmp-from-sg-1111111111111111","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-1111111111"]
+TestTerraformCompleteExample 2022-08-26T22:28:29Z retry.go:91: terraform [output -no-color -json egress_keys]
+TestTerraformCompleteExample 2022-08-26T22:28:29Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
+TestTerraformCompleteExample 2022-08-26T22:28:29Z logger.go:66: ["egress-443-443-tcp-to-pl-1111111111","egress-80-80-tcp-to-pl-1111111111","egress-all-all-all-to-self","egress-all-all-icmp-to-sg-1111111111111111","egress-all-all-to-public","egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-1111111111"]
+TestTerraformCompleteExample 2022-08-26T22:28:29Z retry.go:91: terraform [output -no-color -json disabled_sg_id]
+TestTerraformCompleteExample 2022-08-26T22:28:29Z logger.go:66: Running command terraform with args [output -no-color -json disabled_sg_id]
+TestTerraformCompleteExample 2022-08-26T22:28:30Z logger.go:66: "I was not created"
+    terraform_complete_test.go:46:
+        	Error Trace:	/workspaces/terraform-aws-security-group-v2/test/terraform_complete_test.go:46
+        	Error:      	Not equal:
+        	            	expected: "[ingress-0-0-all-from-self ingress-0-0-icmp-from-sg-1111111111111111 ingress-443-443-tcp-from-sg-1111111111111111 ingress-80-80-tcp-from-sg-1111111111111111 ingress-all-all-from-10.10.0.0/16,10.20.0.0/24 ingress-postgresql-tcp-from-2001:db8::/64 ingress-ssh-tcp-from-pl-1111111111]"
+        	            	actual  : "[ingress-443-443-tcp-from-sg-1111111111111111 ingress-80-80-tcp-from-sg-1111111111111111 ingress-all-all-all-from-self ingress-all-all-from-10.10.0.0/16,10.20.0.0/24 ingress-all-all-icmp-from-sg-1111111111111111 ingress-postgresql-tcp-from-2001:db8::/64 ingress-ssh-tcp-from-pl-1111111111]"
+
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1 +1 @@
+        	            	-[ingress-0-0-all-from-self ingress-0-0-icmp-from-sg-1111111111111111 ingress-443-443-tcp-from-sg-1111111111111111 ingress-80-80-tcp-from-sg-1111111111111111 ingress-all-all-from-10.10.0.0/16,10.20.0.0/24 ingress-postgresql-tcp-from-2001:db8::/64 ingress-ssh-tcp-from-pl-1111111111]
+        	            	+[ingress-443-443-tcp-from-sg-1111111111111111 ingress-80-80-tcp-from-sg-1111111111111111 ingress-all-all-all-from-self ingress-all-all-from-10.10.0.0/16,10.20.0.0/24 ingress-all-all-icmp-from-sg-1111111111111111 ingress-postgresql-tcp-from-2001:db8::/64 ingress-ssh-tcp-from-pl-1111111111]
+        	Test:       	TestTerraformCompleteExample
+        	Messages:   	Map "[ingress-0-0-all-from-self ingress-0-0-icmp-from-sg-1111111111111111 ingress-443-443-tcp-from-sg-1111111111111111 ingress-80-80-tcp-from-sg-1111111111111111 ingress-all-all-from-10.10.0.0/16,10.20.0.0/24 ingress-postgresql-tcp-from-2001:db8::/64 ingress-ssh-tcp-from-pl-1111111111]" should match "[ingress-443-443-tcp-from-sg-1111111111111111 ingress-80-80-tcp-from-sg-1111111111111111 ingress-all-all-all-from-self ingress-all-all-from-10.10.0.0/16,10.20.0.0/24 ingress-all-all-icmp-from-sg-1111111111111111 ingress-postgresql-tcp-from-2001:db8::/64 ingress-ssh-tcp-from-pl-1111111111]"
+    terraform_complete_test.go:47:
+        	Error Trace:	/workspaces/terraform-aws-security-group-v2/test/terraform_complete_test.go:47
+        	Error:      	Not equal:
+        	            	expected: "[egress-0-0-all-to-self egress-0-0-icmp-to-sg-1111111111111111 egress-443-443-tcp-to-pl-1111111111 egress-80-80-tcp-to-pl-1111111111 egress-all-all-to-public egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-postgresql-tcp-to-2001:db8::/64 egress-ssh-tcp-to-pl-1111111111]"
+        	            	actual  : "[egress-443-443-tcp-to-pl-1111111111 egress-80-80-tcp-to-pl-1111111111 egress-all-all-all-to-self egress-all-all-icmp-to-sg-1111111111111111 egress-all-all-to-public egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-postgresql-tcp-to-2001:db8::/64 egress-ssh-tcp-to-pl-1111111111]"
+
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1 +1 @@
+        	            	-[egress-0-0-all-to-self egress-0-0-icmp-to-sg-1111111111111111 egress-443-443-tcp-to-pl-1111111111 egress-80-80-tcp-to-pl-1111111111 egress-all-all-to-public egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-postgresql-tcp-to-2001:db8::/64 egress-ssh-tcp-to-pl-1111111111]
+        	            	+[egress-443-443-tcp-to-pl-1111111111 egress-80-80-tcp-to-pl-1111111111 egress-all-all-all-to-self egress-all-all-icmp-to-sg-1111111111111111 egress-all-all-to-public egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-postgresql-tcp-to-2001:db8::/64 egress-ssh-tcp-to-pl-1111111111]
+        	Test:       	TestTerraformCompleteExample
+        	Messages:   	Map "[egress-0-0-all-to-self egress-0-0-icmp-to-sg-1111111111111111 egress-443-443-tcp-to-pl-1111111111 egress-80-80-tcp-to-pl-1111111111 egress-all-all-to-public egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-postgresql-tcp-to-2001:db8::/64 egress-ssh-tcp-to-pl-1111111111]" should match "[egress-443-443-tcp-to-pl-1111111111 egress-80-80-tcp-to-pl-1111111111 egress-all-all-all-to-self egress-all-all-icmp-to-sg-1111111111111111 egress-all-all-to-public egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-postgresql-tcp-to-2001:db8::/64 egress-ssh-tcp-to-pl-1111111111]"
+TestTerraformCompleteExample 2022-08-26T22:28:30Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:30Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:33Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:33Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:33Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformCompleteExample 2022-08-26T22:28:34Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: Outputs:
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: disabled_sg_id = "I was not created"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: egress = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-all-all-all-to-self" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = true
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-all-all-to-public" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "::/0",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: egress_keys = [
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-all-all-all-to-self",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-all-all-to-public",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: ingress = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 443
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 80
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-all-all-all-from-self" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = true
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 0
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "from_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:       "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     ])
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "self" = false
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "to_port" = 22
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:     "type" = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: ingress_keys = [
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-all-all-all-from-self",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: ]
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: terratest = {
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: }
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:36Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:38Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:38Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:39Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:40Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:40Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformCompleteExample 2022-08-26T22:28:40Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:40Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformCompleteExample 2022-08-26T22:28:40Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformCompleteExample 2022-08-26T22:28:40Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:40Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCompleteExample 2022-08-26T22:28:42Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:42Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:43Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - destroy
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - address_family = "IPv4" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:111111111111:prefix-list/pl-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id             = "pl-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - max_entries    = 5 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - name           = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - owner_id       = "111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - tags           = {} -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - tags_all       = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - version        = 1 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - entry {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description = "Primary" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # aws_security_group.other will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group" "other" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description            = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress                 = [] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ingress                = [] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - name                   = "ex-complete-other" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - tags                   = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "Name" = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - tags_all               = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "Name"       = "ex-complete-other"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description            = "ex-complete" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress                 = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "::/0",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = true
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ingress                = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = true
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - from_port        = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                   - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:                 ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - security_groups  = []
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - self             = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - to_port          = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             },
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - name                   = "ex-complete" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - tags                   = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "Name" = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - tags_all               = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "Example"    = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "Name"       = "ex-complete"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - timeouts {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - create = "10m" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - delete = "15m" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "Managed by Terraform" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 80 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 80 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description              = "Managed by Terraform" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port                = 80 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port                  = 80 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "https-443-tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description              = "https-443-tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port                = 443 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port                  = 443 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "egress_all_to_public_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "::/0",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = true -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port                = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port                  = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type                     = "egress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description       = "ingress-all-all-all-from-self" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self              = true -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"] will be destroyed
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - from_port                = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - self                     = false -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - to_port                  = 0 -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66: Plan: 0 to add, 0 to change, 18 to destroy.
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66: Changes to Outputs:
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - arn            = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - disabled_sg_id = "I was not created" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - egress         = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress-443-443-tcp-to-pl-1111111111          = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress-80-80-tcp-to-pl-1111111111            = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress-all-all-all-to-self                          = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "egress-all-all-all-to-self"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = true
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress-all-all-icmp-to-sg-1111111111111111                  = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress-all-all-to-public                            = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "0.0.0.0/0",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "Opening up ports to connect out to the public internet is generally to be avoided. Please see [no-public-egress-sgr](https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/vpc/no-public-egress-sgr/) for more information"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "::/0",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64"            = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - egress-ssh-tcp-to-pl-1111111111                       = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "egress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - egress_keys    = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-443-443-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-80-80-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-all-all-all-to-self",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-all-all-icmp-to-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-all-all-to-public",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "egress-ssh-tcp-to-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - id             = "sg-1111111111111111" -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - ingress        = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ingress-443-443-tcp-from-sg-1111111111111111    = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "https-443-tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 443
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ingress-80-80-tcp-from-sg-1111111111111111      = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "Managed by Terraform"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 80
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ingress-all-all-all-from-self                    = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "ingress-all-all-all-from-self"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = true
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "10.10.0.0/16",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "-1"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ingress-all-all-icmp-from-sg-1111111111111111            = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "icmp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 0
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64"      = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 5432
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - ingress-ssh-tcp-from-pl-1111111111                 = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - description              = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - from_port                = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:               - "pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:             ]
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - self                     = false
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - source_security_group_id = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - timeouts                 = null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - to_port                  = 22
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:           - type                     = "ingress"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:         }
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - ingress_keys   = [
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-443-443-tcp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-80-80-tcp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-all-all-all-from-self",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-all-all-icmp-from-sg-1111111111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - "ingress-ssh-tcp-from-pl-1111111111",
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     ] -> null
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:   - terratest      = {
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - aws_ec2_managed_prefix_list_other_id = "pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - aws_security_group_other_id          = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - data_aws_prefix_list_private_s3_id   = "pl-1111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:       - data_aws_security_group_default_id   = "sg-1111111111111111"
+TestTerraformCompleteExample 2022-08-26T22:28:44Z logger.go:66:     } -> null
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:45Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:46Z logger.go:66: module.sg.aws_security_group_rule.egress_all_to_public_rules["egress-all-all-to-public"]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-26T22:28:46Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:46Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 2s
+TestTerraformCompleteExample 2022-08-26T22:28:46Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 3s
+TestTerraformCompleteExample 2022-08-26T22:28:47Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:48Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 3s
+TestTerraformCompleteExample 2022-08-26T22:28:48Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:48Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destruction complete after 4s
+TestTerraformCompleteExample 2022-08-26T22:28:48Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:49Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 5s
+TestTerraformCompleteExample 2022-08-26T22:28:50Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destruction complete after 5s
+TestTerraformCompleteExample 2022-08-26T22:28:50Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-26T22:28:51Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-26T22:28:52Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-26T22:28:52Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-26T22:28:52Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-1111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-26T22:28:54Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Destruction complete after 6s
+TestTerraformCompleteExample 2022-08-26T22:28:54Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-26T22:28:55Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-26T22:28:55Z logger.go:66: aws_security_group.other: Destroying... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:55Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
+TestTerraformCompleteExample 2022-08-26T22:28:56Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-26T22:28:56Z logger.go:66: aws_security_group.other: Destruction complete after 1s
+TestTerraformCompleteExample 2022-08-26T22:29:00Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
+TestTerraformCompleteExample 2022-08-26T22:29:00Z logger.go:66:
+TestTerraformCompleteExample 2022-08-26T22:29:00Z logger.go:66: Destroy complete! Resources: 18 destroyed.
+--- FAIL: TestTerraformCompleteExample (53.91s)
+FAIL
+FAIL	command-line-arguments	53.921s
+FAIL

--- a/test/terraform_computed_rules_test.log
+++ b/test/terraform_computed_rules_test.log
@@ -1,702 +1,702 @@
 === RUN   TestTerraformComputedRulesExample
-TestTerraformComputedRulesExample 2022-08-26T17:24:07Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:07Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:07Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformComputedRulesExample 2022-08-26T17:24:07Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:07Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformComputedRulesExample 2022-08-26T17:24:08Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:08Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformComputedRulesExample 2022-08-26T17:24:08Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: [0m[32m
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: should now work.
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:09Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + create
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66: Terraform will perform the following actions:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + address_family = "IPv4"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + arn            = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + id             = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + max_entries    = 5
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + name           = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + owner_id       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + tags_all       = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + version        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + entry {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + cidr        = "172.31.0.0/16"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + description = "Primary"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   # aws_security_group.other will be created
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + resource "aws_security_group" "other" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + description            = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + id                     = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + name                   = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + tags                   = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "Name" = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + tags_all               = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "Name"       = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + description            = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + id                     = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + name                   = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + tags                   = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "Name" = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + tags_all               = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + "Name"       = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + timeouts {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + create = "10m"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:           + delete = "15m"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + description              = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + from_port                = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + to_port                  = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + type                     = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + description              = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + from_port                = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + to_port                  = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + type                     = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + from_port                = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + prefix_list_ids          = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + to_port                  = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + type                     = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + description              = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + from_port                = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + id                       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + to_port                  = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + type                     = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66: Plan: 7 to add, 0 to change, 0 to destroy.
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66: Changes to Outputs:
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + arn          = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + egress       = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + egress_keys  = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + id           = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + ingress      = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + ingress_keys = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:   + terratest    = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + aws_ec2_managed_prefix_list_other_id = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:       + aws_security_group_other_id          = (known after apply)
-TestTerraformComputedRulesExample 2022-08-26T17:24:12Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:13Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
-TestTerraformComputedRulesExample 2022-08-26T17:24:13Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-26T17:24:13Z logger.go:66: aws_security_group.other: Creating...
-TestTerraformComputedRulesExample 2022-08-26T17:24:14Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 1s [id=pl-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:15Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 2s [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:15Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-26T17:24:15Z logger.go:66: aws_security_group.other: Creation complete after 2s [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:15Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-26T17:24:15Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-26T17:24:15Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
-TestTerraformComputedRulesExample 2022-08-26T17:24:16Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:17Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 2s [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 3s [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: Outputs:
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: egress = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "from_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:       "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     ])
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "to_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "type" = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "from_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:       "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     ])
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "to_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "type" = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: }
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: egress_keys = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: ingress = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "from_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "to_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "type" = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "from_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "to_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:     "type" = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: }
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: ingress_keys = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: terratest = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: }
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z retry.go:91: terraform [output -no-color -json terratest]
-TestTerraformComputedRulesExample 2022-08-26T17:24:18Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
-TestTerraformComputedRulesExample 2022-08-26T17:24:19Z logger.go:66: {"aws_ec2_managed_prefix_list_other_id":"pl-1111111111","aws_security_group_other_id":"sg-1111111111111111"}
-TestTerraformComputedRulesExample 2022-08-26T17:24:19Z retry.go:91: terraform [output -no-color -json ingress_keys]
-TestTerraformComputedRulesExample 2022-08-26T17:24:19Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
-TestTerraformComputedRulesExample 2022-08-26T17:24:20Z logger.go:66: ["ingress-443-443-tcp-from-sg-1111111111111111","ingress-80-80-tcp-from-sg-1111111111111111"]
-TestTerraformComputedRulesExample 2022-08-26T17:24:20Z retry.go:91: terraform [output -no-color -json egress_keys]
-TestTerraformComputedRulesExample 2022-08-26T17:24:20Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
-TestTerraformComputedRulesExample 2022-08-26T17:24:21Z logger.go:66: ["egress-443-443-tcp-to-pl-1111111111","egress-80-80-tcp-to-pl-1111111111"]
-TestTerraformComputedRulesExample 2022-08-26T17:24:21Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:21Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:24Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:25Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:25Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformComputedRulesExample 2022-08-26T17:24:25Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:25Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformComputedRulesExample 2022-08-26T17:24:25Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: Outputs:
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: egress = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "from_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:       "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     ])
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "to_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "type" = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "from_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:       "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     ])
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "to_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "type" = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: }
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: egress_keys = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: ingress = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "description" = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "from_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "to_port" = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "type" = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "description" = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "from_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "protocol" = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "self" = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "to_port" = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:     "type" = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   }
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: }
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: ingress_keys = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: terratest = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: }
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:26Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:28Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:29Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformComputedRulesExample 2022-08-26T17:24:32Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformComputedRulesExample 2022-08-26T17:24:32Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:32Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:32Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:32Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - destroy
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: Terraform will perform the following actions:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - address_family = "IPv4" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:111111111111:prefix-list/pl-1111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - id             = "pl-1111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - max_entries    = 5 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - name           = "ex-computed-rules-other" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - owner_id       = "111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - tags           = {} -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - tags_all       = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - version        = 1 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - entry {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - description = "Primary" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   # aws_security_group.other will be destroyed
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - resource "aws_security_group" "other" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - description            = "ex-computed-rules-other" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - egress                 = [] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - ingress                = [] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - name                   = "ex-computed-rules-other" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - tags                   = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "Name" = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - tags_all               = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "Name"       = "ex-computed-rules-other"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - description            = "ex-computed-rules" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - egress                 = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - description      = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - from_port        = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                   - "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - security_groups  = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - to_port          = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - from_port        = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                   - "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - security_groups  = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - to_port          = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - ingress                = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - description      = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - from_port        = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - security_groups  = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - to_port          = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - cidr_blocks      = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - description      = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - from_port        = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - protocol         = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - security_groups  = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:                 ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - self             = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - to_port          = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:             },
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - name                   = "ex-computed-rules" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - tags                   = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "Name" = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - tags_all               = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "Example"    = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "Name"       = "ex-computed-rules"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - timeouts {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - create = "10m" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - delete = "15m" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - description       = "Managed by Terraform" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - from_port         = 80 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - self              = false -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - to_port           = 80 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - type              = "egress" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - description              = "Managed by Terraform" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - from_port                = 80 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - self                     = false -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - to_port                  = 80 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - description       = "https-443-tcp" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         ] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - self              = false -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - type              = "egress" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - description              = "https-443-tcp" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - from_port                = 443 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - self                     = false -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - to_port                  = 443 -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: Plan: 0 to add, 0 to change, 7 to destroy.
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66: Changes to Outputs:
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - egress       = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - egress-443-443-tcp-to-pl-1111111111 = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - cidr_blocks              = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - description              = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - from_port                = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:             ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - source_security_group_id = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - timeouts                 = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - to_port                  = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - type                     = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - egress-80-80-tcp-to-pl-1111111111   = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - cidr_blocks              = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - description              = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - from_port                = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:               - "pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:             ]
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - source_security_group_id = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - timeouts                 = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - to_port                  = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - type                     = "egress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - egress_keys  = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - "egress-443-443-tcp-to-pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - "egress-80-80-tcp-to-pl-1111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     ] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - id           = "sg-1111111111111111" -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - ingress      = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - ingress-443-443-tcp-from-sg-1111111111111111 = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - cidr_blocks              = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - description              = "https-443-tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - from_port                = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - timeouts                 = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - to_port                  = 443
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - type                     = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - ingress-80-80-tcp-from-sg-1111111111111111   = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - cidr_blocks              = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - description              = "Managed by Terraform"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - from_port                = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - self                     = false
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - timeouts                 = null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - to_port                  = 80
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:           - type                     = "ingress"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:         }
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - ingress_keys = [
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - "ingress-443-443-tcp-from-sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - "ingress-80-80-tcp-from-sg-1111111111111111",
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     ] -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:   - terratest    = {
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - aws_ec2_managed_prefix_list_other_id = "pl-1111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:       - aws_security_group_other_id          = "sg-1111111111111111"
-TestTerraformComputedRulesExample 2022-08-26T17:24:33Z logger.go:66:     } -> null
-TestTerraformComputedRulesExample 2022-08-26T17:24:34Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:34Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:34Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:34Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:35Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 0s
-TestTerraformComputedRulesExample 2022-08-26T17:24:36Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 1s
-TestTerraformComputedRulesExample 2022-08-26T17:24:36Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 2s
-TestTerraformComputedRulesExample 2022-08-26T17:24:36Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-1111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:37Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 2s
-TestTerraformComputedRulesExample 2022-08-26T17:24:37Z logger.go:66: aws_security_group.other: Destroying... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:37Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
-TestTerraformComputedRulesExample 2022-08-26T17:24:38Z logger.go:66: aws_security_group.other: Destruction complete after 1s
-TestTerraformComputedRulesExample 2022-08-26T17:24:38Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformComputedRulesExample 2022-08-26T17:24:44Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
-TestTerraformComputedRulesExample 2022-08-26T17:24:44Z logger.go:66:
-TestTerraformComputedRulesExample 2022-08-26T17:24:44Z logger.go:66: Destroy complete! Resources: 7 destroyed.
---- PASS: TestTerraformComputedRulesExample (36.59s)
+TestTerraformComputedRulesExample 2022-08-26T22:30:25Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:25Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:26Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformComputedRulesExample 2022-08-26T22:30:26Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:26Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformComputedRulesExample 2022-08-26T22:30:27Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:27Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformComputedRulesExample 2022-08-26T22:30:27Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: [0m[32m
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: should now work.
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:28Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:31Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformComputedRulesExample 2022-08-26T22:30:31Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + create
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66: Terraform will perform the following actions:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be created
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + address_family = "IPv4"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + arn            = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + id             = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + max_entries    = 5
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + name           = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + owner_id       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + tags_all       = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + version        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + entry {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + cidr        = "172.31.0.0/16"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + description = "Primary"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   # aws_security_group.other will be created
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + resource "aws_security_group" "other" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + description            = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + id                     = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + name                   = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + tags                   = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "Name" = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + tags_all               = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "Name"       = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + description            = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + id                     = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + name                   = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + tags                   = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "Name" = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + tags_all               = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + "Name"       = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + timeouts {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + create = "10m"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:           + delete = "15m"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + description              = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + from_port                = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + to_port                  = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + type                     = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + description              = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + from_port                = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + to_port                  = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + type                     = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + from_port                = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + prefix_list_ids          = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + to_port                  = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + type                     = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be created
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + description              = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + from_port                = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + id                       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + to_port                  = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + type                     = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66: Plan: 7 to add, 0 to change, 0 to destroy.
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66: Changes to Outputs:
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + arn          = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + egress       = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + egress_keys  = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + id           = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + ingress      = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + ingress_keys = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:   + terratest    = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + aws_ec2_managed_prefix_list_other_id = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:       + aws_security_group_other_id          = (known after apply)
+TestTerraformComputedRulesExample 2022-08-26T22:30:32Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:34Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-26T22:30:34Z logger.go:66: aws_ec2_managed_prefix_list.other: Creating...
+TestTerraformComputedRulesExample 2022-08-26T22:30:34Z logger.go:66: aws_security_group.other: Creating...
+TestTerraformComputedRulesExample 2022-08-26T22:30:35Z logger.go:66: aws_ec2_managed_prefix_list.other: Creation complete after 2s [id=pl-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:36Z logger.go:66: aws_security_group.other: Creation complete after 3s [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:36Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 3s [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:36Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-26T22:30:36Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-26T22:30:36Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-26T22:30:36Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creating...
+TestTerraformComputedRulesExample 2022-08-26T22:30:37Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Creation complete after 1s [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:38Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Creation complete after 2s [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:39Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Creation complete after 2s [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Creation complete after 3s [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: Outputs:
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: egress = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "from_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:       "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     ])
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "to_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "type" = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "from_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:       "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     ])
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "to_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "type" = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: }
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: egress_keys = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: ingress = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "from_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "to_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "type" = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "from_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "to_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:     "type" = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: }
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: ingress_keys = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: terratest = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: }
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z retry.go:91: terraform [output -no-color -json terratest]
+TestTerraformComputedRulesExample 2022-08-26T22:30:40Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
+TestTerraformComputedRulesExample 2022-08-26T22:30:41Z logger.go:66: {"aws_ec2_managed_prefix_list_other_id":"pl-1111111111","aws_security_group_other_id":"sg-1111111111111111"}
+TestTerraformComputedRulesExample 2022-08-26T22:30:41Z retry.go:91: terraform [output -no-color -json ingress_keys]
+TestTerraformComputedRulesExample 2022-08-26T22:30:41Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
+TestTerraformComputedRulesExample 2022-08-26T22:30:42Z logger.go:66: ["ingress-443-443-tcp-from-sg-1111111111111111","ingress-80-80-tcp-from-sg-1111111111111111"]
+TestTerraformComputedRulesExample 2022-08-26T22:30:42Z retry.go:91: terraform [output -no-color -json egress_keys]
+TestTerraformComputedRulesExample 2022-08-26T22:30:42Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
+TestTerraformComputedRulesExample 2022-08-26T22:30:42Z logger.go:66: ["egress-443-443-tcp-to-pl-1111111111","egress-80-80-tcp-to-pl-1111111111"]
+TestTerraformComputedRulesExample 2022-08-26T22:30:42Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:42Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:45Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformComputedRulesExample 2022-08-26T22:30:46Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: Outputs:
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: egress = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "from_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:       "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     ])
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "to_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "type" = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "from_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:       "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     ])
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "to_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "type" = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: }
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: egress_keys = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "egress-443-443-tcp-to-pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "egress-80-80-tcp-to-pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: ingress = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "description" = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "from_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "to_port" = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "type" = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111" = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "description" = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "from_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "protocol" = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "self" = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "to_port" = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:     "type" = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   }
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: }
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: ingress_keys = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "ingress-443-443-tcp-from-sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "ingress-80-80-tcp-from-sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: terratest = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "aws_ec2_managed_prefix_list_other_id" = "pl-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66:   "aws_security_group_other_id" = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: }
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:48Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:50Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:51Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformComputedRulesExample 2022-08-26T22:30:54Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: aws_security_group.other: Refreshing state... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: aws_ec2_managed_prefix_list.other: Refreshing state... [id=pl-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:55Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - destroy
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66: Terraform will perform the following actions:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   # aws_ec2_managed_prefix_list.other will be destroyed
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - resource "aws_ec2_managed_prefix_list" "other" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - address_family = "IPv4" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - arn            = "arn:aws:ec2:us-west-2:111111111111:prefix-list/pl-1111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - id             = "pl-1111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - max_entries    = 5 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - name           = "ex-computed-rules-other" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - owner_id       = "111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - tags           = {} -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - tags_all       = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - version        = 1 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - entry {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - cidr        = "172.31.0.0/16" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - description = "Primary" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   # aws_security_group.other will be destroyed
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - resource "aws_security_group" "other" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - description            = "ex-computed-rules-other" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - egress                 = [] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - ingress                = [] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - name                   = "ex-computed-rules-other" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - tags                   = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "Name" = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - tags_all               = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "Name"       = "ex-computed-rules-other"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - description            = "ex-computed-rules" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - egress                 = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - description      = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - from_port        = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                   - "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - security_groups  = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - to_port          = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - from_port        = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                   - "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - security_groups  = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - to_port          = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - ingress                = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - description      = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - from_port        = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - security_groups  = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - to_port          = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - cidr_blocks      = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - description      = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - from_port        = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - protocol         = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - security_groups  = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:                 ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - self             = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - to_port          = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:             },
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - name                   = "ex-computed-rules" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - tags                   = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "Name" = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - tags_all               = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "Example"    = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "Name"       = "ex-computed-rules"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - timeouts {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - create = "10m" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - delete = "15m" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   # module.sg.aws_security_group_rule.computed_egress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - resource "aws_security_group_rule" "computed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - description       = "Managed by Terraform" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - from_port         = 80 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - self              = false -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - to_port           = 80 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - type              = "egress" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   # module.sg.aws_security_group_rule.computed_ingress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - resource "aws_security_group_rule" "computed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - description              = "Managed by Terraform" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - from_port                = 80 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - self                     = false -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - to_port                  = 80 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_egress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_egress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - description       = "https-443-tcp" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         ] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - self              = false -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - type              = "egress" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   # module.sg.aws_security_group_rule.computed_managed_ingress_rules[0] will be destroyed
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - resource "aws_security_group_rule" "computed_managed_ingress_rules" {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - description              = "https-443-tcp" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - from_port                = 443 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - self                     = false -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - to_port                  = 443 -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66: Plan: 0 to add, 0 to change, 7 to destroy.
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66: Changes to Outputs:
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - egress       = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - egress-443-443-tcp-to-pl-1111111111 = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - cidr_blocks              = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - description              = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - from_port                = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:             ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - source_security_group_id = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - timeouts                 = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - to_port                  = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - type                     = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - egress-80-80-tcp-to-pl-1111111111   = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - cidr_blocks              = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - description              = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - from_port                = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:               - "pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:             ]
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - source_security_group_id = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - timeouts                 = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - to_port                  = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - type                     = "egress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - egress_keys  = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - "egress-443-443-tcp-to-pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - "egress-80-80-tcp-to-pl-1111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     ] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - id           = "sg-1111111111111111" -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - ingress      = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - ingress-443-443-tcp-from-sg-1111111111111111 = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - cidr_blocks              = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - description              = "https-443-tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - from_port                = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - timeouts                 = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - to_port                  = 443
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - type                     = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - ingress-80-80-tcp-from-sg-1111111111111111   = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - cidr_blocks              = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - description              = "Managed by Terraform"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - from_port                = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - self                     = false
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - timeouts                 = null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - to_port                  = 80
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:           - type                     = "ingress"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:         }
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - ingress_keys = [
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - "ingress-443-443-tcp-from-sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - "ingress-80-80-tcp-from-sg-1111111111111111",
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     ] -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:   - terratest    = {
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - aws_ec2_managed_prefix_list_other_id = "pl-1111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:       - aws_security_group_other_id          = "sg-1111111111111111"
+TestTerraformComputedRulesExample 2022-08-26T22:30:56Z logger.go:66:     } -> null
+TestTerraformComputedRulesExample 2022-08-26T22:30:57Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:57Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:57Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:57Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destroying... [id=sgrule-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:30:58Z logger.go:66: module.sg.aws_security_group_rule.computed_ingress_rules[0]: Destruction complete after 0s
+TestTerraformComputedRulesExample 2022-08-26T22:30:58Z logger.go:66: module.sg.aws_security_group_rule.computed_egress_rules[0]: Destruction complete after 1s
+TestTerraformComputedRulesExample 2022-08-26T22:30:59Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_ingress_rules[0]: Destruction complete after 2s
+TestTerraformComputedRulesExample 2022-08-26T22:31:00Z logger.go:66: module.sg.aws_security_group_rule.computed_managed_egress_rules[0]: Destruction complete after 2s
+TestTerraformComputedRulesExample 2022-08-26T22:31:00Z logger.go:66: aws_security_group.other: Destroying... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:31:00Z logger.go:66: aws_ec2_managed_prefix_list.other: Destroying... [id=pl-1111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:31:00Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
+TestTerraformComputedRulesExample 2022-08-26T22:31:01Z logger.go:66: aws_security_group.other: Destruction complete after 1s
+TestTerraformComputedRulesExample 2022-08-26T22:31:01Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformComputedRulesExample 2022-08-26T22:31:07Z logger.go:66: aws_ec2_managed_prefix_list.other: Destruction complete after 7s
+TestTerraformComputedRulesExample 2022-08-26T22:31:07Z logger.go:66:
+TestTerraformComputedRulesExample 2022-08-26T22:31:07Z logger.go:66: Destroy complete! Resources: 7 destroyed.
+--- PASS: TestTerraformComputedRulesExample (41.60s)
 PASS
-ok  	command-line-arguments	36.606s
+ok  	command-line-arguments	41.613s

--- a/test/terraform_custom_rules_test.log
+++ b/test/terraform_custom_rules_test.log
@@ -1,1234 +1,1263 @@
 === RUN   TestTerraformCustomRulesExample
-TestTerraformCustomRulesExample 2022-08-26T17:22:41Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformCustomRulesExample 2022-08-26T17:22:41Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformCustomRulesExample 2022-08-26T17:22:41Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformCustomRulesExample 2022-08-26T17:22:42Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:42Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformCustomRulesExample 2022-08-26T17:22:42Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:42Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformCustomRulesExample 2022-08-26T17:22:42Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: [0m[32m
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: should now work.
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:22:43Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:22:46Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:22:46Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:22:46Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + create
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description            = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                     = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + name                   = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + tags                   = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "Name" = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + tags_all               = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "Example"    = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "Name"       = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + timeouts {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + create = "10m"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + delete = "15m"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "egress-0-0-all-to-self"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = true
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "egress-22-22-tcp-to-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "egress-450-350-tcp-to-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 350
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 450
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "ingress-0-0-all-from-self"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = true
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "ingress-22-22-tcp-from-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + cidr_blocks              = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be created
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + description              = "ingress-450-350-tcp-from-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + from_port                = 350
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + id                       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:           + "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:         ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + to_port                  = 450
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66: Changes to Outputs:
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + arn          = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + egress       = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + egress_keys  = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + id           = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + ingress      = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + ingress_keys = (known after apply)
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:   + terratest    = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + data_aws_prefix_list_private_s3_id = "pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:       + data_aws_security_group_default_id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:47Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:22:48Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 3s [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:50Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformCustomRulesExample 2022-08-26T17:22:51Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Creation complete after 0s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:52Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:53Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Creation complete after 2s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:54Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Creation complete after 3s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:54Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Creation complete after 4s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:55Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Creation complete after 5s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:56Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creation complete after 6s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:57Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 6s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 7s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creation complete after 8s [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: Outputs:
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: egress = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-0-0-all-to-self" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "egress-0-0-all-to-self"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = true
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "egress-22-22-tcp-to-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "egress-450-350-tcp-to-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 350
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 450
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: egress_keys = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-0-0-all-to-self",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: ingress = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-0-0-all-from-self" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "ingress-0-0-all-from-self"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = true
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "ingress-22-22-tcp-from-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64" = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "description" = "ingress-450-350-tcp-from-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "from_port" = 350
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:       "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "to_port" = 450
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: ingress_keys = [
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-0-0-all-from-self",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: ]
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: terratest = {
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: }
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z retry.go:91: terraform [output -no-color -json terratest]
-TestTerraformCustomRulesExample 2022-08-26T17:22:58Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
-TestTerraformCustomRulesExample 2022-08-26T17:22:59Z logger.go:66: {"data_aws_prefix_list_private_s3_id":"pl-1111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
-TestTerraformCustomRulesExample 2022-08-26T17:22:59Z retry.go:91: terraform [output -no-color -json ingress_keys]
-TestTerraformCustomRulesExample 2022-08-26T17:22:59Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
-TestTerraformCustomRulesExample 2022-08-26T17:23:00Z logger.go:66: ["ingress-0-0-all-from-self","ingress-0-0-icmp-from-sg-1111111111111111","ingress-22-22-tcp-from-pl-1111111111","ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24","ingress-450-350-tcp-from-2001:db8::/64"]
-TestTerraformCustomRulesExample 2022-08-26T17:23:00Z retry.go:91: terraform [output -no-color -json egress_keys]
-TestTerraformCustomRulesExample 2022-08-26T17:23:00Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
-TestTerraformCustomRulesExample 2022-08-26T17:23:01Z logger.go:66: ["egress-0-0-all-to-self","egress-0-0-icmp-to-sg-1111111111111111","egress-22-22-tcp-to-pl-1111111111","egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-450-350-tcp-to-2001:db8::/64"]
-TestTerraformCustomRulesExample 2022-08-26T17:23:01Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:23:01Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:23:04Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:04Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:04Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:04Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:04Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:04Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformCustomRulesExample 2022-08-26T17:23:05Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: Outputs:
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: egress = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-0-0-all-to-self" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "egress-0-0-all-to-self"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = true
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "egress-22-22-tcp-to-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "egress-450-350-tcp-to-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 350
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 450
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: egress_keys = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-0-0-all-to-self",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-0-0-icmp-to-sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: ingress = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-0-0-all-from-self" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "ingress-0-0-all-from-self"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = true
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "ingress-22-22-tcp-from-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "description" = "ingress-450-350-tcp-from-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "from_port" = 350
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:       "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     ])
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "protocol" = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "self" = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "to_port" = 450
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:     "type" = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: ingress_keys = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-0-0-all-from-self",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-0-0-icmp-from-sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: terratest = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: }
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:23:06Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:23:09Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:09Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:23:10Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformCustomRulesExample 2022-08-26T17:23:13Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:13Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:14Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - destroy
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66: Terraform will perform the following actions:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description            = "ex-custom-rules" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - egress                 = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "egress-0-0-all-to-self"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = true
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "egress-22-22-tcp-to-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "egress-450-350-tcp-to-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 350
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 450
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - ingress                = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "ingress-0-0-all-from-self"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = true
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "ingress-22-22-tcp-from-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - cidr_blocks      = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - description      = "ingress-450-350-tcp-from-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - from_port        = 350
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:                 ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - protocol         = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - security_groups  = []
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - self             = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - to_port          = 450
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             },
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - name                   = "ex-custom-rules" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - tags                   = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "Name" = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         } -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - tags_all               = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "Example"    = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "Name"       = "ex-custom-rules"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         } -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - timeouts {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - create = "10m" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - delete = "15m" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "egress-0-0-all-to-self" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = true -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description              = "egress-0-0-icmp-to-sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port                = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self                     = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port                  = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type                     = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "egress-22-22-tcp-to-pl-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "egress-450-350-tcp-to-2001:db8::/64" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 350 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 450 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "egress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "ingress-0-0-all-from-self" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = true -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description              = "ingress-0-0-icmp-from-sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port                = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self                     = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port                  = 0 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "ingress-22-22-tcp-from-pl-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - cidr_blocks       = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be destroyed
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - description       = "ingress-450-350-tcp-from-2001:db8::/64" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - from_port         = 350 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - self              = false -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - to_port           = 450 -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66: Changes to Outputs:
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - egress       = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - egress-0-0-all-to-self                            = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "egress-0-0-all-to-self"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = true
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - egress-0-0-icmp-to-sg-1111111111111111                    = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "egress-0-0-icmp-to-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - egress-22-22-tcp-to-pl-1111111111                   = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "egress-22-22-tcp-to-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "egress-450-350-tcp-to-2001:db8::/64"             = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "egress-450-350-tcp-to-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 350
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 450
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "egress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     } -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - egress_keys  = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "egress-0-0-all-to-self",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "egress-0-0-icmp-to-sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "egress-22-22-tcp-to-pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "egress-450-350-tcp-to-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - id           = "sg-1111111111111111" -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - ingress      = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - ingress-0-0-all-from-self                            = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "ingress-0-0-all-from-self"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "-1"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = true
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - ingress-0-0-icmp-from-sg-1111111111111111                    = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "ingress-0-0-icmp-from-sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "icmp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 0
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - ingress-22-22-tcp-from-pl-1111111111                   = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "ingress-22-22-tcp-from-pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 22
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "10.10.0.0/16",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 443
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "ingress-450-350-tcp-from-2001:db8::/64"             = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - cidr_blocks              = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - description              = "ingress-450-350-tcp-from-2001:db8::/64"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - from_port                = 350
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:               - "2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:             ]
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - self                     = false
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - source_security_group_id = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - timeouts                 = null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - to_port                  = 450
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:           - type                     = "ingress"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:         }
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     } -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - ingress_keys = [
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "ingress-0-0-all-from-self",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "ingress-0-0-icmp-from-sg-1111111111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "ingress-22-22-tcp-from-pl-1111111111",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - "ingress-450-350-tcp-from-2001:db8::/64",
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     ] -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:   - terratest    = {
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - data_aws_prefix_list_private_s3_id = "pl-1111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:       - data_aws_security_group_default_id = "sg-1111111111111111"
-TestTerraformCustomRulesExample 2022-08-26T17:23:15Z logger.go:66:     } -> null
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Destroying... [id=sgrule-1111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:16Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 1s
-TestTerraformCustomRulesExample 2022-08-26T17:23:17Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Destruction complete after 2s
-TestTerraformCustomRulesExample 2022-08-26T17:23:18Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-icmp-to-sg-1111111111111111"]: Destruction complete after 2s
-TestTerraformCustomRulesExample 2022-08-26T17:23:18Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destruction complete after 3s
-TestTerraformCustomRulesExample 2022-08-26T17:23:19Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-icmp-from-sg-1111111111111111"]: Destruction complete after 4s
-TestTerraformCustomRulesExample 2022-08-26T17:23:20Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destruction complete after 4s
-TestTerraformCustomRulesExample 2022-08-26T17:23:21Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-0-0-all-to-self"]: Destruction complete after 5s
-TestTerraformCustomRulesExample 2022-08-26T17:23:21Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-0-0-all-from-self"]: Destruction complete after 6s
-TestTerraformCustomRulesExample 2022-08-26T17:23:22Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 6s
-TestTerraformCustomRulesExample 2022-08-26T17:23:23Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Destruction complete after 7s
-TestTerraformCustomRulesExample 2022-08-26T17:23:23Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
-TestTerraformCustomRulesExample 2022-08-26T17:23:24Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformCustomRulesExample 2022-08-26T17:23:24Z logger.go:66:
-TestTerraformCustomRulesExample 2022-08-26T17:23:24Z logger.go:66: Destroy complete! Resources: 11 destroyed.
---- PASS: TestTerraformCustomRulesExample (42.34s)
-PASS
-ok  	command-line-arguments	42.351s
+TestTerraformCustomRulesExample 2022-08-26T22:29:01Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:01Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:01Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformCustomRulesExample 2022-08-26T22:29:01Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:01Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformCustomRulesExample 2022-08-26T22:29:02Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:02Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformCustomRulesExample 2022-08-26T22:29:02Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: [0m[32m
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: should now work.
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:03Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:06Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:06Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:06Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + create
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description            = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                     = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + name                   = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + tags                   = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "Name" = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + tags_all               = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "Example"    = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "Name"       = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + timeouts {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + create = "10m"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + delete = "15m"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "egress-22-22-tcp-to-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "egress-450-350-tcp-to-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "egress-all-all-all-to-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "ingress-22-22-tcp-from-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + cidr_blocks              = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "ingress-450-350-tcp-from-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:           + "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:         ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "ingress-all-all-all-from-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"] will be created
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + description              = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + id                       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66: Changes to Outputs:
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + arn          = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + egress       = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + egress_keys  = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + id           = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + ingress      = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + ingress_keys = (known after apply)
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:   + terratest    = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + data_aws_prefix_list_private_s3_id = "pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:       + data_aws_security_group_default_id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:07Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:08Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 3s [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:10Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creating...
+TestTerraformCustomRulesExample 2022-08-26T22:29:11Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Creation complete after 0s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:12Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Creation complete after 1s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:12Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 2s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:13Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Creation complete after 3s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:14Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Creation complete after 4s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:15Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Creation complete after 5s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:16Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Creation complete after 5s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:17Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Creation complete after 6s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:17Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Creation complete after 7s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 8s [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: Outputs:
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: egress = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "egress-22-22-tcp-to-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "egress-450-350-tcp-to-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-all-all-all-to-self" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "egress-all-all-all-to-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: egress_keys = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-all-all-all-to-self",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: ingress = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "ingress-22-22-tcp-from-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "ingress-450-350-tcp-from-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:       "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-all-all-all-from-self" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "ingress-all-all-all-from-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "description" = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: ingress_keys = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-all-all-all-from-self",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: terratest = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: }
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z retry.go:91: terraform [output -no-color -json terratest]
+TestTerraformCustomRulesExample 2022-08-26T22:29:18Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
+TestTerraformCustomRulesExample 2022-08-26T22:29:19Z logger.go:66: {"data_aws_prefix_list_private_s3_id":"pl-1111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
+TestTerraformCustomRulesExample 2022-08-26T22:29:19Z retry.go:91: terraform [output -no-color -json ingress_keys]
+TestTerraformCustomRulesExample 2022-08-26T22:29:19Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
+TestTerraformCustomRulesExample 2022-08-26T22:29:20Z logger.go:66: ["ingress-22-22-tcp-from-pl-1111111111","ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24","ingress-450-350-tcp-from-2001:db8::/64","ingress-all-all-all-from-self","ingress-all-all-icmp-from-sg-1111111111111111"]
+TestTerraformCustomRulesExample 2022-08-26T22:29:20Z retry.go:91: terraform [output -no-color -json egress_keys]
+TestTerraformCustomRulesExample 2022-08-26T22:29:20Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
+TestTerraformCustomRulesExample 2022-08-26T22:29:21Z logger.go:66: ["egress-22-22-tcp-to-pl-1111111111","egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-450-350-tcp-to-2001:db8::/64","egress-all-all-all-to-self","egress-all-all-icmp-to-sg-1111111111111111"]
+    terraform_custom_rules_test.go:42:
+        	Error Trace:	/workspaces/terraform-aws-security-group-v2/test/terraform_custom_rules_test.go:42
+        	Error:      	Not equal:
+        	            	expected: "[ingress-0-0-all-from-self ingress-0-0-icmp-from-sg-1111111111111111 ingress-22-22-tcp-from-pl-1111111111 ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24 ingress-450-350-tcp-from-2001:db8::/64]"
+        	            	actual  : "[ingress-22-22-tcp-from-pl-1111111111 ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24 ingress-450-350-tcp-from-2001:db8::/64 ingress-all-all-all-from-self ingress-all-all-icmp-from-sg-1111111111111111]"
+
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1 +1 @@
+        	            	-[ingress-0-0-all-from-self ingress-0-0-icmp-from-sg-1111111111111111 ingress-22-22-tcp-from-pl-1111111111 ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24 ingress-450-350-tcp-from-2001:db8::/64]
+        	            	+[ingress-22-22-tcp-from-pl-1111111111 ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24 ingress-450-350-tcp-from-2001:db8::/64 ingress-all-all-all-from-self ingress-all-all-icmp-from-sg-1111111111111111]
+        	Test:       	TestTerraformCustomRulesExample
+        	Messages:   	Map "[ingress-0-0-all-from-self ingress-0-0-icmp-from-sg-1111111111111111 ingress-22-22-tcp-from-pl-1111111111 ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24 ingress-450-350-tcp-from-2001:db8::/64]" should match "[ingress-22-22-tcp-from-pl-1111111111 ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24 ingress-450-350-tcp-from-2001:db8::/64 ingress-all-all-all-from-self ingress-all-all-icmp-from-sg-1111111111111111]"
+    terraform_custom_rules_test.go:43:
+        	Error Trace:	/workspaces/terraform-aws-security-group-v2/test/terraform_custom_rules_test.go:43
+        	Error:      	Not equal:
+        	            	expected: "[egress-0-0-all-to-self egress-0-0-icmp-to-sg-1111111111111111 egress-22-22-tcp-to-pl-1111111111 egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-450-350-tcp-to-2001:db8::/64]"
+        	            	actual  : "[egress-22-22-tcp-to-pl-1111111111 egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-450-350-tcp-to-2001:db8::/64 egress-all-all-all-to-self egress-all-all-icmp-to-sg-1111111111111111]"
+
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1 +1 @@
+        	            	-[egress-0-0-all-to-self egress-0-0-icmp-to-sg-1111111111111111 egress-22-22-tcp-to-pl-1111111111 egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-450-350-tcp-to-2001:db8::/64]
+        	            	+[egress-22-22-tcp-to-pl-1111111111 egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-450-350-tcp-to-2001:db8::/64 egress-all-all-all-to-self egress-all-all-icmp-to-sg-1111111111111111]
+        	Test:       	TestTerraformCustomRulesExample
+        	Messages:   	Map "[egress-0-0-all-to-self egress-0-0-icmp-to-sg-1111111111111111 egress-22-22-tcp-to-pl-1111111111 egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-450-350-tcp-to-2001:db8::/64]" should match "[egress-22-22-tcp-to-pl-1111111111 egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24 egress-450-350-tcp-to-2001:db8::/64 egress-all-all-all-to-self egress-all-all-icmp-to-sg-1111111111111111]"
+TestTerraformCustomRulesExample 2022-08-26T22:29:21Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:21Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformCustomRulesExample 2022-08-26T22:29:24Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: Outputs:
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: egress = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "egress-22-22-tcp-to-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "egress-450-350-tcp-to-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-all-all-all-to-self" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "egress-all-all-all-to-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: egress_keys = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-22-22-tcp-to-pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-450-350-tcp-to-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-all-all-all-to-self",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "egress-all-all-icmp-to-sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: ingress = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "ingress-22-22-tcp-from-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "ingress-450-350-tcp-from-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:       "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     ])
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-all-all-all-from-self" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "ingress-all-all-all-from-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "description" = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "from_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "protocol" = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "self" = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "to_port" = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:     "type" = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: ingress_keys = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-22-22-tcp-from-pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-450-350-tcp-from-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-all-all-all-from-self",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "ingress-all-all-icmp-from-sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: terratest = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: }
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:25Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:28Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:28Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:28Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:29Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformCustomRulesExample 2022-08-26T22:29:32Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:32Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:32Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 1s [id=pl-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:32Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:32Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformCustomRulesExample 2022-08-26T22:29:32Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:32Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - destroy
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: Terraform will perform the following actions:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description            = "ex-custom-rules" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - egress                 = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "egress-22-22-tcp-to-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "egress-450-350-tcp-to-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "egress-all-all-all-to-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - ingress                = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "ingress-22-22-tcp-from-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "ingress-450-350-tcp-from-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "ingress-all-all-all-from-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - cidr_blocks      = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - description      = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - from_port        = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - protocol         = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - security_groups  = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:                 ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - self             = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - to_port          = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             },
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - name                   = "ex-custom-rules" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - tags                   = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "Name" = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         } -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - tags_all               = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "Example"    = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "Name"       = "ex-custom-rules"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         } -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - timeouts {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - create = "10m" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - delete = "15m" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "egress-22-22-tcp-to-pl-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "egress-450-350-tcp-to-2001:db8::/64" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 350 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 450 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "egress-all-all-all-to-self" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = true -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description              = "egress-all-all-icmp-to-sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port                = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self                     = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port                  = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type                     = "egress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "ingress-22-22-tcp-from-pl-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - cidr_blocks       = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "ingress-450-350-tcp-from-2001:db8::/64" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 350 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 450 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description       = "ingress-all-all-all-from-self" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self              = true -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   # module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"] will be destroyed
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - resource "aws_security_group_rule" "rules" {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - description              = "ingress-all-all-icmp-from-sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - from_port                = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - self                     = false -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - to_port                  = 0 -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66: Changes to Outputs:
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - egress       = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - egress-22-22-tcp-to-pl-1111111111                   = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "egress-22-22-tcp-to-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "egress-450-350-tcp-to-2001:db8::/64"             = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "egress-450-350-tcp-to-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - egress-all-all-all-to-self                        = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "egress-all-all-all-to-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - egress-all-all-icmp-to-sg-1111111111111111                = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "egress-all-all-icmp-to-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "egress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     } -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - egress_keys  = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "egress-22-22-tcp-to-pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "egress-450-350-tcp-to-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "egress-all-all-all-to-self",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "egress-all-all-icmp-to-sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - id           = "sg-1111111111111111" -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - ingress      = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - ingress-22-22-tcp-from-pl-1111111111                   = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "ingress-22-22-tcp-from-pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 22
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "10.10.0.0/16",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 443
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "ingress-450-350-tcp-from-2001:db8::/64"             = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "ingress-450-350-tcp-from-2001:db8::/64"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 350
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:               - "2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:             ]
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 450
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - ingress-all-all-all-from-self                        = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "ingress-all-all-all-from-self"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "-1"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = true
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - ingress-all-all-icmp-from-sg-1111111111111111                = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - cidr_blocks              = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - description              = "ingress-all-all-icmp-from-sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - from_port                = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - protocol                 = "icmp"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - self                     = false
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - timeouts                 = null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - to_port                  = 0
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:           - type                     = "ingress"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:         }
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     } -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - ingress_keys = [
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "ingress-22-22-tcp-from-pl-1111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "ingress-450-350-tcp-from-2001:db8::/64",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "ingress-all-all-all-from-self",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - "ingress-all-all-icmp-from-sg-1111111111111111",
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     ] -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:   - terratest    = {
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - data_aws_prefix_list_private_s3_id = "pl-1111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:       - data_aws_security_group_default_id = "sg-1111111111111111"
+TestTerraformCustomRulesExample 2022-08-26T22:29:33Z logger.go:66:     } -> null
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:34Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:35Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-all-from-self"]: Destruction complete after 0s
+TestTerraformCustomRulesExample 2022-08-26T22:29:36Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-450-350-tcp-from-2001:db8::/64"]: Destruction complete after 1s
+TestTerraformCustomRulesExample 2022-08-26T22:29:36Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-22-22-tcp-to-pl-1111111111"]: Destruction complete after 2s
+TestTerraformCustomRulesExample 2022-08-26T22:29:37Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-450-350-tcp-to-2001:db8::/64"]: Destruction complete after 2s
+TestTerraformCustomRulesExample 2022-08-26T22:29:38Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-icmp-to-sg-1111111111111111"]: Destruction complete after 3s
+TestTerraformCustomRulesExample 2022-08-26T22:29:38Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-443-443-tcp-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 4s
+TestTerraformCustomRulesExample 2022-08-26T22:29:39Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-22-22-tcp-from-pl-1111111111"]: Destruction complete after 4s
+TestTerraformCustomRulesExample 2022-08-26T22:29:40Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-all-all-all-to-self"]: Destruction complete after 5s
+TestTerraformCustomRulesExample 2022-08-26T22:29:40Z logger.go:66: module.sg.aws_security_group_rule.rules["egress-443-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 6s
+TestTerraformCustomRulesExample 2022-08-26T22:29:41Z logger.go:66: module.sg.aws_security_group_rule.rules["ingress-all-all-icmp-from-sg-1111111111111111"]: Destruction complete after 7s
+TestTerraformCustomRulesExample 2022-08-26T22:29:41Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
+TestTerraformCustomRulesExample 2022-08-26T22:29:42Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformCustomRulesExample 2022-08-26T22:29:42Z logger.go:66:
+TestTerraformCustomRulesExample 2022-08-26T22:29:42Z logger.go:66: Destroy complete! Resources: 11 destroyed.
+--- FAIL: TestTerraformCustomRulesExample (41.20s)
+FAIL
+FAIL	command-line-arguments	41.210s
+FAIL

--- a/test/terraform_managed_rules_test.log
+++ b/test/terraform_managed_rules_test.log
@@ -1,1234 +1,1234 @@
 === RUN   TestTerraformManagedRulesExample
-TestTerraformManagedRulesExample 2022-08-26T17:23:25Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:25Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:25Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformManagedRulesExample 2022-08-26T17:23:25Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:25Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformManagedRulesExample 2022-08-26T17:23:26Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:26Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformManagedRulesExample 2022-08-26T17:23:26Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: [0m[32m
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: should now work.
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:27Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:29Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:29Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + create
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: Terraform will perform the following actions:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group" "self" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description            = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                     = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + name                   = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + tags                   = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "Name" = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + tags_all               = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "Example"    = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "Name"       = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + timeouts {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + create = "10m"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + delete = "15m"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "egress-all-all-to-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "egress-all-icmp-to-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + cidr_blocks              = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + cidr_blocks              = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "ingress-all-all-from-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "ingress-all-icmp-from-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + ipv6_cidr_blocks         = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be created
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + from_port                = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + id                       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + prefix_list_ids          = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:           + "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:         ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + source_security_group_id = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + to_port                  = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66: Changes to Outputs:
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + arn          = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + egress       = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + egress_keys  = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + id           = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + ingress      = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + ingress_keys = (known after apply)
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:   + terratest    = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + data_aws_prefix_list_private_s3_id = "pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:       + data_aws_security_group_default_id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:30Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:31Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 2s [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
-TestTerraformManagedRulesExample 2022-08-26T17:23:34Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:35Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Creation complete after 2s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:36Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creation complete after 3s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:37Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creation complete after 3s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:38Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 4s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:38Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 5s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 6s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:40Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creation complete after 6s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:41Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Creation complete after 7s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 8s [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: Outputs:
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: egress = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-all-all-to-self" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "egress-all-all-to-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "egress-all-icmp-to-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: egress_keys = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-all-all-to-self",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: ingress = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-all-all-from-self" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "ingress-all-all-from-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "ingress-all-icmp-from-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "from_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:       "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "to_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: ingress_keys = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-all-all-from-self",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: terratest = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: }
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z retry.go:91: terraform [output -no-color -json terratest]
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: {"data_aws_prefix_list_private_s3_id":"pl-1111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z retry.go:91: terraform [output -no-color -json ingress_keys]
-TestTerraformManagedRulesExample 2022-08-26T17:23:42Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
-TestTerraformManagedRulesExample 2022-08-26T17:23:43Z logger.go:66: ["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-all-all-from-self","ingress-all-icmp-from-sg-1111111111111111","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-1111111111"]
-TestTerraformManagedRulesExample 2022-08-26T17:23:43Z retry.go:91: terraform [output -no-color -json egress_keys]
-TestTerraformManagedRulesExample 2022-08-26T17:23:43Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
-TestTerraformManagedRulesExample 2022-08-26T17:23:44Z logger.go:66: ["egress-all-all-to-self","egress-all-icmp-to-sg-1111111111111111","egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-1111111111"]
-TestTerraformManagedRulesExample 2022-08-26T17:23:44Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:44Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 1s [id=pl-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:47Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:48Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:48Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformManagedRulesExample 2022-08-26T17:23:48Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:48Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformManagedRulesExample 2022-08-26T17:23:48Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: Outputs:
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: egress = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-all-all-to-self" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "egress-all-all-to-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "egress-all-icmp-to-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: egress_keys = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-all-all-to-self",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: ingress = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-all-all-from-self" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "ingress-all-all-from-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "ingress-all-icmp-from-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "from_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "prefix_list_ids" = tolist([
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:       "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     ])
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "protocol" = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "self" = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "source_security_group_id" = tostring(null)
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "to_port" = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:     "type" = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: ingress_keys = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-all-all-from-self",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: terratest = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: }
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:49Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:53Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformManagedRulesExample 2022-08-26T17:23:55Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:55Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - destroy
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66: Terraform will perform the following actions:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group" "self" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description            = "ex-managed-rules" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - egress                 = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "egress-all-all-to-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "egress-all-icmp-to-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - ingress                = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "ingress-all-all-from-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "ingress-all-icmp-from-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - cidr_blocks      = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - from_port        = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - prefix_list_ids  = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                   - "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:                 ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - protocol         = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - security_groups  = []
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - self             = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - to_port          = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             },
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - name                   = "ex-managed-rules" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - tags                   = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "Name" = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         } -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - tags_all               = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "Example"    = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "Name"       = "ex-managed-rules"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         } -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - timeouts {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - create = "10m" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - delete = "15m" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "egress-all-all-to-self" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = true -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description              = "egress-all-icmp-to-sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port                = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self                     = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port                  = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type                     = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - cidr_blocks       = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 443 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 443 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "egress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - cidr_blocks       = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "ingress-all-all-from-self" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "-1" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = true -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description              = "ingress-all-icmp-from-sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port                = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol                 = "icmp" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self                     = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port                  = 0 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - ipv6_cidr_blocks  = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 5432 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be destroyed
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - from_port         = 22 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - id                = "sgrule-1111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - prefix_list_ids   = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - protocol          = "tcp" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - self              = false -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - to_port           = 22 -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - type              = "ingress" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66: Changes to Outputs:
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - egress       = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - egress-all-all-to-self                              = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "egress-all-all-to-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - egress-all-icmp-to-sg-1111111111111111                      = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "egress-all-icmp-to-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 443
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64"            = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "egress-postgresql-tcp-to-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - egress-ssh-tcp-to-pl-1111111111                       = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "egress-ssh-tcp-to-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "egress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     } -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - egress_keys  = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "egress-all-all-to-self",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "egress-all-icmp-to-sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "egress-ssh-tcp-to-pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - id           = "sg-1111111111111111" -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - ingress      = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "10.10.0.0/16",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - ingress-all-all-from-self                        = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "ingress-all-all-from-self"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "-1"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = true
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - ingress-all-icmp-from-sg-1111111111111111                = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "ingress-all-icmp-from-sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "icmp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 0
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64"      = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "ingress-postgresql-tcp-from-2001:db8::/64"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 5432
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - ingress-ssh-tcp-from-pl-1111111111                 = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - cidr_blocks              = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - description              = "ingress-ssh-tcp-from-pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - from_port                = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - prefix_list_ids          = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:               - "pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:             ]
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - self                     = false
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - source_security_group_id = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - timeouts                 = null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - to_port                  = 22
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:           - type                     = "ingress"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:         }
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     } -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - ingress_keys = [
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "ingress-all-all-from-self",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "ingress-all-icmp-from-sg-1111111111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - "ingress-ssh-tcp-from-pl-1111111111",
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     ] -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:   - terratest    = {
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - data_aws_prefix_list_private_s3_id = "pl-1111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:       - data_aws_security_group_default_id = "sg-1111111111111111"
-TestTerraformManagedRulesExample 2022-08-26T17:23:57Z logger.go:66:     } -> null
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:23:59Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Destruction complete after 0s
-TestTerraformManagedRulesExample 2022-08-26T17:23:59Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destruction complete after 1s
-TestTerraformManagedRulesExample 2022-08-26T17:24:00Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Destruction complete after 1s
-TestTerraformManagedRulesExample 2022-08-26T17:24:01Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destruction complete after 2s
-TestTerraformManagedRulesExample 2022-08-26T17:24:01Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 3s
-TestTerraformManagedRulesExample 2022-08-26T17:24:02Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destruction complete after 3s
-TestTerraformManagedRulesExample 2022-08-26T17:24:03Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destruction complete after 4s
-TestTerraformManagedRulesExample 2022-08-26T17:24:03Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 5s
-TestTerraformManagedRulesExample 2022-08-26T17:24:04Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 6s
-TestTerraformManagedRulesExample 2022-08-26T17:24:05Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 6s
-TestTerraformManagedRulesExample 2022-08-26T17:24:05Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
-TestTerraformManagedRulesExample 2022-08-26T17:24:06Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
-TestTerraformManagedRulesExample 2022-08-26T17:24:06Z logger.go:66:
-TestTerraformManagedRulesExample 2022-08-26T17:24:06Z logger.go:66: Destroy complete! Resources: 11 destroyed.
---- PASS: TestTerraformManagedRulesExample (41.20s)
+TestTerraformManagedRulesExample 2022-08-26T22:29:43Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformManagedRulesExample 2022-08-26T22:29:43Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformManagedRulesExample 2022-08-26T22:29:43Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformManagedRulesExample 2022-08-26T22:29:43Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:43Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformManagedRulesExample 2022-08-26T22:29:44Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:44Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformManagedRulesExample 2022-08-26T22:29:44Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: [0m[32m
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: should now work.
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:29:45Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:29:48Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:29:48Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:29:48Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + create
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: Terraform will perform the following actions:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group.self[0] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group" "self" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description            = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                     = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + name                   = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + tags                   = {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "Name" = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + tags_all               = {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "Example"    = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "Name"       = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + timeouts {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + create = "10m"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + delete = "15m"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "egress-all-all-to-self"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = true
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "egress-all-icmp-to-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + cidr_blocks              = [
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 443
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 443
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 22
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 22
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + cidr_blocks              = [
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "ingress-all-all-from-self"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = true
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "ingress-all-icmp-from-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + ipv6_cidr_blocks         = [
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be created
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + description              = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + from_port                = 22
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + id                       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + prefix_list_ids          = [
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:           + "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:         ]
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + source_security_group_id = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + to_port                  = 22
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: Plan: 11 to add, 0 to change, 0 to destroy.
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66: Changes to Outputs:
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + arn          = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + egress       = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + egress_keys  = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + id           = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + ingress      = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + ingress_keys = (known after apply)
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:   + terratest    = {
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + data_aws_prefix_list_private_s3_id = "pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:       + data_aws_security_group_default_id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:29:49Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:29:50Z logger.go:66: module.sg.aws_security_group.self[0]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group.self[0]: Creation complete after 3s [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:52Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Creating...
+TestTerraformManagedRulesExample 2022-08-26T22:29:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Creation complete after 0s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:54Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 1s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:54Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Creation complete after 2s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:55Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Creation complete after 3s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:56Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Creation complete after 3s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:57Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Creation complete after 4s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:57Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Creation complete after 5s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:58Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Creation complete after 6s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:29:59Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Creation complete after 6s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Creation complete after 7s [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: Outputs:
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: egress = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-all-all-to-self" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "egress-all-all-to-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "egress-all-icmp-to-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: egress_keys = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-all-all-to-self",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: ingress = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-all-all-from-self" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "ingress-all-all-from-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "ingress-all-icmp-from-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "from_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:       "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "to_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: ingress_keys = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-all-all-from-self",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: terratest = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: }
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z retry.go:91: terraform [output -no-color -json terratest]
+TestTerraformManagedRulesExample 2022-08-26T22:30:00Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
+TestTerraformManagedRulesExample 2022-08-26T22:30:01Z logger.go:66: {"data_aws_prefix_list_private_s3_id":"pl-1111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
+TestTerraformManagedRulesExample 2022-08-26T22:30:01Z retry.go:91: terraform [output -no-color -json ingress_keys]
+TestTerraformManagedRulesExample 2022-08-26T22:30:01Z logger.go:66: Running command terraform with args [output -no-color -json ingress_keys]
+TestTerraformManagedRulesExample 2022-08-26T22:30:02Z logger.go:66: ["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24","ingress-all-all-from-self","ingress-all-icmp-from-sg-1111111111111111","ingress-postgresql-tcp-from-2001:db8::/64","ingress-ssh-tcp-from-pl-1111111111"]
+TestTerraformManagedRulesExample 2022-08-26T22:30:02Z retry.go:91: terraform [output -no-color -json egress_keys]
+TestTerraformManagedRulesExample 2022-08-26T22:30:02Z logger.go:66: Running command terraform with args [output -no-color -json egress_keys]
+TestTerraformManagedRulesExample 2022-08-26T22:30:02Z logger.go:66: ["egress-all-all-to-self","egress-all-icmp-to-sg-1111111111111111","egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24","egress-postgresql-tcp-to-2001:db8::/64","egress-ssh-tcp-to-pl-1111111111"]
+TestTerraformManagedRulesExample 2022-08-26T22:30:02Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:30:02Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:30:05Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:05Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: data.aws_security_group.default: Read complete after 1s [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformManagedRulesExample 2022-08-26T22:30:06Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66: Outputs:
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66: arn = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66: egress = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:   "egress-all-all-to-self" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "description" = "egress-all-all-to-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "protocol" = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "self" = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "description" = "egress-all-icmp-to-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "protocol" = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:       "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:       "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "description" = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "from_port" = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "to_port" = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "description" = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "from_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:07Z logger.go:66:       "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "to_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "description" = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "from_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:       "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "to_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "type" = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: egress_keys = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "egress-all-all-to-self",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "egress-all-icmp-to-sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "egress-ssh-tcp-to-pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: ingress = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:       "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:       "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "description" = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "protocol" = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-all-all-from-self" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "description" = "ingress-all-all-from-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "protocol" = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "self" = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "description" = "ingress-all-icmp-from-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "from_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "protocol" = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "to_port" = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "description" = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "from_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "ipv6_cidr_blocks" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:       "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "to_port" = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "description" = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "from_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "prefix_list_ids" = tolist([
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:       "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     ])
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "protocol" = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "self" = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "source_security_group_id" = tostring(null)
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "to_port" = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:     "type" = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: ingress_keys = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-all-all-from-self",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-all-icmp-from-sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "ingress-ssh-tcp-from-pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: terratest = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "data_aws_prefix_list_private_s3_id" = "pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: }
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:30:08Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:30:10Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:10Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:11Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:12Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:12Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformManagedRulesExample 2022-08-26T22:30:12Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:12Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformManagedRulesExample 2022-08-26T22:30:12Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformManagedRulesExample 2022-08-26T22:30:12Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:30:12Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformManagedRulesExample 2022-08-26T22:30:14Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:14Z logger.go:66: data.aws_prefix_list.private_s3: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: data.aws_prefix_list.private_s3: Read complete after 0s [id=pl-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group.self[0]: Refreshing state... [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:15Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - destroy
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66: Terraform will perform the following actions:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group.self[0] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group" "self" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description            = "ex-managed-rules" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - egress                 = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "egress-all-all-to-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "egress-all-icmp-to-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - ingress                = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "ingress-all-all-from-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "ingress-all-icmp-from-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - cidr_blocks      = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - description      = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - from_port        = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - prefix_list_ids  = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                   - "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:                 ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - protocol         = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - security_groups  = []
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - self             = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - to_port          = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             },
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - name                   = "ex-managed-rules" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - tags                   = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "Name" = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         } -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - tags_all               = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "Example"    = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "Name"       = "ex-managed-rules"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         } -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - timeouts {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - create = "10m" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - delete = "15m" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "egress-all-all-to-self" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = true -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description              = "egress-all-icmp-to-sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port                = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self                     = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port                  = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type                     = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - cidr_blocks       = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 443 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 443 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "egress-postgresql-tcp-to-2001:db8::/64" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "egress-ssh-tcp-to-pl-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "egress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - cidr_blocks       = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "ingress-all-all-from-self" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "-1" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = true -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description              = "ingress-all-icmp-from-sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port                = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol                 = "icmp" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self                     = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port                  = 0 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "ingress-postgresql-tcp-from-2001:db8::/64" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - ipv6_cidr_blocks  = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 5432 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"] will be destroyed
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - description       = "ingress-ssh-tcp-from-pl-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - from_port         = 22 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - id                = "sgrule-1111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - prefix_list_ids   = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - protocol          = "tcp" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - security_group_id = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - self              = false -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - to_port           = 22 -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - type              = "ingress" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66: Plan: 0 to add, 0 to change, 11 to destroy.
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66: Changes to Outputs:
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - arn          = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - egress       = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - egress-all-all-to-self                              = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "egress-all-all-to-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - egress-all-icmp-to-sg-1111111111111111                      = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "egress-all-icmp-to-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 443
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64"            = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "egress-postgresql-tcp-to-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - egress-ssh-tcp-to-pl-1111111111                       = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "egress-ssh-tcp-to-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "egress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     } -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - egress_keys  = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "egress-all-all-to-self",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "egress-all-icmp-to-sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "egress-postgresql-tcp-to-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "egress-ssh-tcp-to-pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - id           = "sg-1111111111111111" -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - ingress      = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24" = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "10.10.0.0/16",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - ingress-all-all-from-self                        = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "ingress-all-all-from-self"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "-1"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = true
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - ingress-all-icmp-from-sg-1111111111111111                = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "ingress-all-icmp-from-sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "icmp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 0
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64"      = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "ingress-postgresql-tcp-from-2001:db8::/64"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 5432
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - ingress-ssh-tcp-from-pl-1111111111                 = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - cidr_blocks              = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - description              = "ingress-ssh-tcp-from-pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - from_port                = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - prefix_list_ids          = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:               - "pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:             ]
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - self                     = false
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - source_security_group_id = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - timeouts                 = null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - to_port                  = 22
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:           - type                     = "ingress"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:         }
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     } -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - ingress_keys = [
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "ingress-all-all-from-10.10.0.0/16,10.20.0.0/24",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "ingress-all-all-from-self",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "ingress-all-icmp-from-sg-1111111111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "ingress-postgresql-tcp-from-2001:db8::/64",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - "ingress-ssh-tcp-from-pl-1111111111",
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     ] -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:   - terratest    = {
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - data_aws_prefix_list_private_s3_id = "pl-1111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:       - data_aws_security_group_default_id = "sg-1111111111111111"
+TestTerraformManagedRulesExample 2022-08-26T22:30:16Z logger.go:66:     } -> null
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:17Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-postgresql-tcp-to-2001:db8::/64"]: Destruction complete after 1s
+TestTerraformManagedRulesExample 2022-08-26T22:30:18Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-https-443-tcp-to-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 1s
+TestTerraformManagedRulesExample 2022-08-26T22:30:19Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-self"]: Destruction complete after 2s
+TestTerraformManagedRulesExample 2022-08-26T22:30:19Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-icmp-to-sg-1111111111111111"]: Destruction complete after 3s
+TestTerraformManagedRulesExample 2022-08-26T22:30:20Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-postgresql-tcp-from-2001:db8::/64"]: Destruction complete after 3s
+TestTerraformManagedRulesExample 2022-08-26T22:30:21Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-ssh-tcp-to-pl-1111111111"]: Destruction complete after 4s
+TestTerraformManagedRulesExample 2022-08-26T22:30:21Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-all-from-10.10.0.0/16,10.20.0.0/24"]: Destruction complete after 5s
+TestTerraformManagedRulesExample 2022-08-26T22:30:22Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["egress-all-all-to-self"]: Destruction complete after 5s
+TestTerraformManagedRulesExample 2022-08-26T22:30:23Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-ssh-tcp-from-pl-1111111111"]: Destruction complete after 6s
+TestTerraformManagedRulesExample 2022-08-26T22:30:23Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-all-icmp-from-sg-1111111111111111"]: Destruction complete after 7s
+TestTerraformManagedRulesExample 2022-08-26T22:30:23Z logger.go:66: module.sg.aws_security_group.self[0]: Destroying... [id=sg-1111111111111111]
+TestTerraformManagedRulesExample 2022-08-26T22:30:24Z logger.go:66: module.sg.aws_security_group.self[0]: Destruction complete after 1s
+TestTerraformManagedRulesExample 2022-08-26T22:30:24Z logger.go:66:
+TestTerraformManagedRulesExample 2022-08-26T22:30:24Z logger.go:66: Destroy complete! Resources: 11 destroyed.
+--- PASS: TestTerraformManagedRulesExample (41.35s)
 PASS
-ok  	command-line-arguments	41.221s
+ok  	command-line-arguments	41.358s

--- a/test/terraform_rules_only_test.log
+++ b/test/terraform_rules_only_test.log
@@ -1,283 +1,283 @@
 === RUN   TestTerraformRulesOnlyExample
-TestTerraformRulesOnlyExample 2022-08-26T17:24:45Z retry.go:91: terraform [init -upgrade=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:45Z logger.go:66: Running command terraform with args [init -upgrade=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:45Z logger.go:66: [0m[1mInitializing modules...[0m
-TestTerraformRulesOnlyExample 2022-08-26T17:24:45Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:45Z logger.go:66: [0m[1mInitializing the backend...[0m
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: [0m[1mInitializing provider plugins...[0m
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: [0m[32m
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: should now work.
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:46Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:49Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + create
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: Terraform will perform the following actions:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   # aws_security_group.pre_existing will be created
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + resource "aws_security_group" "pre_existing" {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + arn                    = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + description            = "ex-rules-only-pre-existing"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + egress                 = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + id                     = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + ingress                = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + name                   = "ex-rules-only-pre-existing"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + name_prefix            = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + owner_id               = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + revoke_rules_on_delete = false
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + tags                   = {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:           + "Name" = "ex-rules-only-pre-existing"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:         }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + tags_all               = {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:           + "Example"    = "ex-rules-only"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:           + "Name"       = "ex-rules-only-pre-existing"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:         }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + vpc_id                 = "vpc-11111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"] will be created
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + description              = "ingress-http-80-tcp-from-sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + from_port                = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + id                       = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + protocol                 = "tcp"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + security_group_id        = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + self                     = false
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + to_port                  = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + type                     = "ingress"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: Plan: 2 to add, 0 to change, 0 to destroy.
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66: Changes to Outputs:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + egress       = {}
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + egress_keys  = []
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + ingress      = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + ingress_keys = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:   + terratest    = {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + aws_security_group_pre_existing_id = (known after apply)
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:       + data_aws_security_group_default_id = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:50Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:51Z logger.go:66: aws_security_group.pre_existing: Creating...
-TestTerraformRulesOnlyExample 2022-08-26T17:24:53Z logger.go:66: aws_security_group.pre_existing: Creation complete after 2s [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:53Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Creating...
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Creation complete after 1s [id=sgrule-1111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: Outputs:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: egress = {}
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: egress_keys = []
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: ingress = {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111" = {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "description" = "ingress-http-80-tcp-from-sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "from_port" = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "protocol" = "tcp"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "self" = false
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "to_port" = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:     "type" = "ingress"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:   }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: ingress_keys = [
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111",
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: ]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: terratest = {
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:   "aws_security_group_pre_existing_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: }
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z retry.go:91: terraform [output -no-color -json terratest]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:54Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:55Z logger.go:66: {"aws_security_group_pre_existing_id":"sg-1111111111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
-TestTerraformRulesOnlyExample 2022-08-26T17:24:55Z retry.go:91: terraform [output -no-color -json ingress]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:55Z logger.go:66: Running command terraform with args [output -no-color -json ingress]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:55Z logger.go:66: {"ingress-http-80-tcp-from-sg-1111111111111111":{"cidr_blocks":null,"description":"ingress-http-80-tcp-from-sg-1111111111111111","from_port":80,"id":"sgrule-1111111111","ipv6_cidr_blocks":null,"prefix_list_ids":null,"protocol":"tcp","security_group_id":"sg-1111111111111111","self":false,"source_security_group_id":"sg-1111111111111111","timeouts":null,"to_port":80,"type":"ingress"}}
-TestTerraformRulesOnlyExample 2022-08-26T17:24:55Z retry.go:91: terraform [output -no-color -json egress]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:55Z logger.go:66: Running command terraform with args [output -no-color -json egress]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:56Z logger.go:66: {}
-TestTerraformRulesOnlyExample 2022-08-26T17:24:56Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:56Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:59Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:24:59Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:59Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:24:59Z logger.go:66: aws_security_group.pre_existing: Refreshing state... [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:59Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:24:59Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:00Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:00Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformRulesOnlyExample 2022-08-26T17:25:00Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:00Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformRulesOnlyExample 2022-08-26T17:25:00Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: Outputs:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: egress = {}
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: egress_keys = []
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: ingress = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111" = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "description" = "ingress-http-80-tcp-from-sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "from_port" = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "id" = "sgrule-1111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "protocol" = "tcp"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "self" = false
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "timeouts" = null /* object */
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "to_port" = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:     "type" = "ingress"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:   }
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: }
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: ingress_keys = [
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111",
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: ]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: terratest = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:   "aws_security_group_pre_existing_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: }
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:01Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:03Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: aws_security_group.pre_existing: Refreshing state... [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: No changes. Your infrastructure matches the configuration.
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: Terraform has compared your real infrastructure against your configuration
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: and found no differences, so no changes are needed.
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:04Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:07Z logger.go:66: data.aws_vpc.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:25:07Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:07Z logger.go:66: data.aws_security_group.default: Reading...
-TestTerraformRulesOnlyExample 2022-08-26T17:25:07Z logger.go:66: aws_security_group.pre_existing: Refreshing state... [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:07Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:07Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66: Terraform used the selected providers to generate the following execution
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66: plan. Resource actions are indicated with the following symbols:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - destroy
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66: Terraform will perform the following actions:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   # aws_security_group.pre_existing will be destroyed
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - resource "aws_security_group" "pre_existing" {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - description            = "ex-rules-only-pre-existing" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - egress                 = [] -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - ingress                = [
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - cidr_blocks      = []
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - description      = "ingress-http-80-tcp-from-sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - from_port        = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - ipv6_cidr_blocks = []
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - prefix_list_ids  = []
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - protocol         = "tcp"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - security_groups  = [
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:                   - "sg-1111111111111111",
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:                 ]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - self             = false
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:               - to_port          = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:             },
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:         ] -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - name                   = "ex-rules-only-pre-existing" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - owner_id               = "111111111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - revoke_rules_on_delete = false -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - tags                   = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - "Name" = "ex-rules-only-pre-existing"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:         } -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - tags_all               = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - "Example"    = "ex-rules-only"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - "Name"       = "ex-rules-only-pre-existing"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:         } -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"] will be destroyed
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - description              = "ingress-http-80-tcp-from-sg-1111111111111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - from_port                = 80 -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - protocol                 = "tcp" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - self                     = false -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - to_port                  = 80 -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - type                     = "ingress" -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:     }
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66: Plan: 0 to add, 0 to change, 2 to destroy.
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66: Changes to Outputs:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - egress       = {} -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - egress_keys  = [] -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - ingress      = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - ingress-http-80-tcp-from-sg-1111111111111111 = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - cidr_blocks              = null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - description              = "ingress-http-80-tcp-from-sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - from_port                = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - id                       = "sgrule-1111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - ipv6_cidr_blocks         = null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - prefix_list_ids          = null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - protocol                 = "tcp"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - self                     = false
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - timeouts                 = null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - to_port                  = 80
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:           - type                     = "ingress"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:         }
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:     } -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - ingress_keys = [
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - "ingress-http-80-tcp-from-sg-1111111111111111",
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:     ] -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:   - terratest    = {
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - aws_security_group_pre_existing_id = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:       - data_aws_security_group_default_id = "sg-1111111111111111"
-TestTerraformRulesOnlyExample 2022-08-26T17:25:08Z logger.go:66:     } -> null
-TestTerraformRulesOnlyExample 2022-08-26T17:25:09Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:09Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Destruction complete after 1s
-TestTerraformRulesOnlyExample 2022-08-26T17:25:09Z logger.go:66: aws_security_group.pre_existing: Destroying... [id=sg-1111111111111111]
-TestTerraformRulesOnlyExample 2022-08-26T17:25:10Z logger.go:66: aws_security_group.pre_existing: Destruction complete after 1s
-TestTerraformRulesOnlyExample 2022-08-26T17:25:10Z logger.go:66:
-TestTerraformRulesOnlyExample 2022-08-26T17:25:10Z logger.go:66: Destroy complete! Resources: 2 destroyed.
---- PASS: TestTerraformRulesOnlyExample (25.74s)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:08Z retry.go:91: terraform [init -upgrade=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:08Z logger.go:66: Running command terraform with args [init -upgrade=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:08Z logger.go:66: [0m[1mInitializing modules...[0m
+TestTerraformRulesOnlyExample 2022-08-26T22:31:08Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:08Z logger.go:66: [0m[1mInitializing the backend...[0m
+TestTerraformRulesOnlyExample 2022-08-26T22:31:09Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:09Z logger.go:66: [0m[1mInitializing provider plugins...[0m
+TestTerraformRulesOnlyExample 2022-08-26T22:31:09Z logger.go:66: - Reusing previous version of hashicorp/aws from the dependency lock file
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: - Using previously-installed hashicorp/aws v4.27.0
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: [0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: [0m[32m
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: any changes that are required for your infrastructure. All Terraform commands
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: should now work.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: If you ever set or change modules or backend configuration for Terraform,
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: commands will detect it and remind you to do so if necessary.[0m
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:10Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + create
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: Terraform will perform the following actions:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   # aws_security_group.pre_existing will be created
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + resource "aws_security_group" "pre_existing" {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + arn                    = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + description            = "ex-rules-only-pre-existing"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + egress                 = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + id                     = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + ingress                = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + name                   = "ex-rules-only-pre-existing"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + name_prefix            = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + owner_id               = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + revoke_rules_on_delete = false
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + tags                   = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:           + "Name" = "ex-rules-only-pre-existing"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:         }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + tags_all               = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:           + "Example"    = "ex-rules-only"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:           + "GithubOrg"  = "aidanmelen"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:           + "GithubRepo" = "terraform-aws-security-group"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:           + "Name"       = "ex-rules-only-pre-existing"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:         }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + vpc_id                 = "vpc-11111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"] will be created
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + resource "aws_security_group_rule" "managed_rules" {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + description              = "ingress-http-80-tcp-from-sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + from_port                = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + id                       = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + protocol                 = "tcp"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + security_group_id        = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + self                     = false
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + source_security_group_id = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + to_port                  = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + type                     = "ingress"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: Plan: 2 to add, 0 to change, 0 to destroy.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66: Changes to Outputs:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + egress       = {}
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + egress_keys  = []
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + ingress      = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + ingress_keys = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:   + terratest    = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + aws_security_group_pre_existing_id = (known after apply)
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:       + data_aws_security_group_default_id = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:14Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:16Z logger.go:66: aws_security_group.pre_existing: Creating...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:18Z logger.go:66: aws_security_group.pre_existing: Creation complete after 2s [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:18Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Creating...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Creation complete after 1s [id=sgrule-1111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: Outputs:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: egress = {}
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: egress_keys = []
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: ingress = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111" = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "description" = "ingress-http-80-tcp-from-sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "from_port" = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "protocol" = "tcp"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "self" = false
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "to_port" = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:     "type" = "ingress"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:   }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: ingress_keys = [
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111",
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: ]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: terratest = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:   "aws_security_group_pre_existing_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z retry.go:91: terraform [output -no-color -json terratest]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:19Z logger.go:66: Running command terraform with args [output -no-color -json terratest]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:20Z logger.go:66: {"aws_security_group_pre_existing_id":"sg-1111111111111111","data_aws_security_group_default_id":"sg-1111111111111111"}
+TestTerraformRulesOnlyExample 2022-08-26T22:31:20Z retry.go:91: terraform [output -no-color -json ingress]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:20Z logger.go:66: Running command terraform with args [output -no-color -json ingress]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:21Z logger.go:66: {"ingress-http-80-tcp-from-sg-1111111111111111":{"cidr_blocks":null,"description":"ingress-http-80-tcp-from-sg-1111111111111111","from_port":80,"id":"sgrule-1111111111","ipv6_cidr_blocks":null,"prefix_list_ids":null,"protocol":"tcp","security_group_id":"sg-1111111111111111","self":false,"source_security_group_id":"sg-1111111111111111","timeouts":null,"to_port":80,"type":"ingress"}}
+TestTerraformRulesOnlyExample 2022-08-26T22:31:21Z retry.go:91: terraform [output -no-color -json egress]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:21Z logger.go:66: Running command terraform with args [output -no-color -json egress]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:22Z logger.go:66: {}
+TestTerraformRulesOnlyExample 2022-08-26T22:31:22Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:22Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: data.aws_vpc.default: Read complete after 1s [id=vpc-11111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: aws_security_group.pre_existing: Refreshing state... [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformRulesOnlyExample 2022-08-26T22:31:26Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: Outputs:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: egress = {}
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: egress_keys = []
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: ingress = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111" = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "cidr_blocks" = tolist(null) /* of string */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "description" = "ingress-http-80-tcp-from-sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "from_port" = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "id" = "sgrule-1111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "ipv6_cidr_blocks" = tolist(null) /* of string */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "prefix_list_ids" = tolist(null) /* of string */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "protocol" = "tcp"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "security_group_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "self" = false
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "source_security_group_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "timeouts" = null /* object */
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "to_port" = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:     "type" = "ingress"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:   }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: ingress_keys = [
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:   "ingress-http-80-tcp-from-sg-1111111111111111",
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: ]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: terratest = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:   "aws_security_group_pre_existing_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66:   "data_aws_security_group_default_id" = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: Running terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:28Z logger.go:66: Running command terraform with args [plan -input=false -detailed-exitcode -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:31Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: aws_security_group.pre_existing: Refreshing state... [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: No changes. Your infrastructure matches the configuration.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: Terraform has compared your real infrastructure against your configuration
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: and found no differences, so no changes are needed.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z retry.go:91: terraform [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:32Z logger.go:66: Running command terraform with args [destroy -auto-approve -input=false -no-color -lock=false]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:36Z logger.go:66: data.aws_vpc.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:36Z logger.go:66: data.aws_vpc.default: Read complete after 0s [id=vpc-11111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:36Z logger.go:66: data.aws_security_group.default: Reading...
+TestTerraformRulesOnlyExample 2022-08-26T22:31:36Z logger.go:66: aws_security_group.pre_existing: Refreshing state... [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:36Z logger.go:66: data.aws_security_group.default: Read complete after 0s [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:36Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Refreshing state... [id=sgrule-1111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66: Terraform used the selected providers to generate the following execution
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66: plan. Resource actions are indicated with the following symbols:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - destroy
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66: Terraform will perform the following actions:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   # aws_security_group.pre_existing will be destroyed
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - resource "aws_security_group" "pre_existing" {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - arn                    = "arn:aws:ec2:us-west-2:111111111111:security-group/sg-1111111111111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - description            = "ex-rules-only-pre-existing" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - egress                 = [] -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - id                     = "sg-1111111111111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - ingress                = [
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - cidr_blocks      = []
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - description      = "ingress-http-80-tcp-from-sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - from_port        = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - ipv6_cidr_blocks = []
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - prefix_list_ids  = []
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - protocol         = "tcp"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - security_groups  = [
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:                   - "sg-1111111111111111",
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:                 ]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - self             = false
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:               - to_port          = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:             },
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:         ] -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - name                   = "ex-rules-only-pre-existing" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - owner_id               = "111111111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - revoke_rules_on_delete = false -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - tags                   = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - "Name" = "ex-rules-only-pre-existing"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:         } -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - tags_all               = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - "Example"    = "ex-rules-only"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - "GithubOrg"  = "aidanmelen"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - "GithubRepo" = "terraform-aws-security-group"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - "Name"       = "ex-rules-only-pre-existing"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:         } -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - vpc_id                 = "vpc-11111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   # module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"] will be destroyed
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - resource "aws_security_group_rule" "managed_rules" {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - description              = "ingress-http-80-tcp-from-sg-1111111111111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - from_port                = 80 -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - id                       = "sgrule-1111111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - protocol                 = "tcp" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - security_group_id        = "sg-1111111111111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - self                     = false -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - source_security_group_id = "sg-1111111111111111" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - to_port                  = 80 -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - type                     = "ingress" -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:     }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66: Plan: 0 to add, 0 to change, 2 to destroy.
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66: Changes to Outputs:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - egress       = {} -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - egress_keys  = [] -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - ingress      = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - ingress-http-80-tcp-from-sg-1111111111111111 = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - cidr_blocks              = null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - description              = "ingress-http-80-tcp-from-sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - from_port                = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - id                       = "sgrule-1111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - ipv6_cidr_blocks         = null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - prefix_list_ids          = null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - protocol                 = "tcp"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - security_group_id        = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - self                     = false
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - source_security_group_id = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - timeouts                 = null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - to_port                  = 80
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:           - type                     = "ingress"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:         }
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:     } -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - ingress_keys = [
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - "ingress-http-80-tcp-from-sg-1111111111111111",
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:     ] -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:   - terratest    = {
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - aws_security_group_pre_existing_id = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:       - data_aws_security_group_default_id = "sg-1111111111111111"
+TestTerraformRulesOnlyExample 2022-08-26T22:31:37Z logger.go:66:     } -> null
+TestTerraformRulesOnlyExample 2022-08-26T22:31:38Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Destroying... [id=sgrule-1111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:39Z logger.go:66: module.sg.aws_security_group_rule.managed_rules["ingress-http-80-tcp-from-sg-1111111111111111"]: Destruction complete after 0s
+TestTerraformRulesOnlyExample 2022-08-26T22:31:39Z logger.go:66: aws_security_group.pre_existing: Destroying... [id=sg-1111111111111111]
+TestTerraformRulesOnlyExample 2022-08-26T22:31:40Z logger.go:66: aws_security_group.pre_existing: Destruction complete after 1s
+TestTerraformRulesOnlyExample 2022-08-26T22:31:40Z logger.go:66:
+TestTerraformRulesOnlyExample 2022-08-26T22:31:40Z logger.go:66: Destroy complete! Resources: 2 destroyed.
+--- PASS: TestTerraformRulesOnlyExample (31.74s)
 PASS
-ok  	command-line-arguments	25.757s
+ok  	command-line-arguments	31.753s


### PR DESCRIPTION
# Fixes

## Proposed Changes
- removed the "_" lookup for "rule". Since there is no sane default, we will just let if fail if the user doesn't pass a valid rule.
- added support for `-1` and `0` for ALL used in `to_port` and `from_port`
